### PR TITLE
Add support for ApplicationELB

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ discovery:
         period: 60
         length: 900
         nilToZero: true
+  - type: "alb"
+    region: eu-west-1
+    searchTags:
+      - Key: kubernetes.io/service-name
+        Value: .*
+    metrics:
+      - name: UnHealthyHostCount
+        statistics: [Maximum]
+        period: 60
+        length: 600
 static:
   - namespace: AWS/AutoScaling
     region: eu-west-1

--- a/src/abstract.go
+++ b/src/abstract.go
@@ -79,7 +79,7 @@ func scrapeStaticJob(resource static, clientCloudwatch cloudwatchInterface) (cw 
 				NilToZero:  &metric.NilToZero,
 			}
 
-			filter := prepareCloudwatchRequest(
+			filter := createGetMetricStatisticsInput(
 				createStaticDimensions(resource.Dimensions),
 				&resource.Namespace,
 				metric,
@@ -122,8 +122,8 @@ func scrapeDiscoveryJob(job discovery, clientTag tagsInterface, clientCloudwatch
 					NilToZero:  &metric.NilToZero,
 				}
 
-				filter := prepareCloudwatchRequest(
-					getDimensions(resource.Service, resource.ID),
+				filter := createGetMetricStatisticsInput(
+					getDimensions(resource.Service, resource.ID, clientCloudwatch),
 					getNamespace(resource.Service),
 					metric,
 				)

--- a/src/aws_tags.go
+++ b/src/aws_tags.go
@@ -43,6 +43,11 @@ func (iface tagsInterface) get(discovery discovery) (resources []*tagsData, err 
 	case "elb":
 		hotfix := aws.String("elasticloadbalancing:loadbalancer")
 		filter = append(filter, hotfix)
+	case "alb":
+		alb := aws.String("elasticloadbalancing:loadbalancer")
+		tg := aws.String("elasticloadbalancing:targetgroup")
+		filter = append(filter, alb)
+		filter = append(filter, tg)
 	case "rds":
 		hotfix := aws.String("rds:db")
 		filter = append(filter, hotfix)

--- a/src/main.go
+++ b/src/main.go
@@ -15,7 +15,7 @@ var (
 	addr              = flag.String("listen-address", ":5000", "The address to listen on.")
 	configFile        = flag.String("config.file", "config.yml", "Path to configuration file.")
 	version           = flag.Bool("v", false, "prints current yace version")
-	supportedServices = []string{"rds", "ec2", "elb", "es", "ec", "s3", "efs", "ebs"}
+	supportedServices = []string{"rds", "ec2", "elb", "alb", "es", "ec", "s3", "efs", "ebs"}
 	debug             = flag.Bool("debug", false, "Add verbose logging")
 	config            = conf{}
 )


### PR DESCRIPTION
Metrics for ApplicationELBs require that you specify multiple dimensions, dimensions that cannot be preconfigured. This PR extends the discovery so that it discovers LoadBalancers (LB) and TargetGroups (TG) in the ApplicationELB Namespace. It then combines TGs with LBs using the ListMetrics interface so that per-TG metrics can be fetched.

Possible future extensions would be to add the per-AZ dimension and possibly cache the metric dimensions to reduce the number of API queries.

TargetGroups and LoadBalancers are both output to the `aws_alb_info` metric. so that they can be joined on `(name)` in PromQL.