### PR TITLE
Allow adding discovered tags to all metrics from a particular service

### DIFF
--- a/src/aws_cloudwatch.go
+++ b/src/aws_cloudwatch.go
@@ -26,6 +26,7 @@ type cloudwatchData struct {
 	Points     []*cloudwatch.Datapoint
 	NilToZero  *bool
 	CustomTags []tag
+	Tags       []tag
 }
 
 func createCloudwatchSession(region *string) *cloudwatch.CloudWatch {
@@ -289,6 +290,9 @@ func migrateCloudwatchToPrometheus(cwd []*cloudwatchData) []*prometheusData {
 
 				for _, label := range c.CustomTags {
 					promLabels["custom_tag_"+label.Key] = label.Value
+				}
+				for _, tag := range c.Tags {
+					promLabels["tag_"+promString(tag.Key)] = tag.Value
 				}
 
 				var value float64 = 0

--- a/src/config.go
+++ b/src/config.go
@@ -7,8 +7,9 @@ import (
 )
 
 type conf struct {
-	Discovery []discovery `yaml:"discovery"`
-	Static    []static    `yaml:"static"`
+	Discovery     []discovery   `yaml:"discovery"`
+	Static        []static      `yaml:"static"`
+	TagsOnMetrics tagsOnMetrics `yaml:"tagsOnMetrics"`
 }
 
 type discovery struct {
@@ -44,6 +45,8 @@ type tag struct {
 	Key   string `yaml:"Key"`
 	Value string `yaml:"Value"`
 }
+
+type tagsOnMetrics map[string][]string
 
 func (c *conf) load(file *string) error {
 	yamlFile, err := ioutil.ReadFile(*file)


### PR DESCRIPTION
A new top-level configuration item `tagsOnMetrics` controls which tags will
be added to metrics for each service.

Fixes #24