### PR TITLE
Fix support for listing multiple statistics per metric

### DIFF
--- a/src/aws_cloudwatch.go
+++ b/src/aws_cloudwatch.go
@@ -46,9 +46,9 @@ func createGetMetricStatisticsInput(dimensions []*cloudwatch.Dimension, namespac
 	var extendedStatistics []*string
 	for _, statistic := range metric.Statistics {
 		if percentile.MatchString(statistic) {
-			extendedStatistics = append(extendedStatistics, &statistic)
+			extendedStatistics = append(extendedStatistics, aws.String(statistic))
 		} else {
-			statistics = append(statistics, &statistic)
+			statistics = append(statistics, aws.String(statistic))
 		}
 	}
 


### PR DESCRIPTION
This avoids creating a slice of pointers to a variable that is later modified.

Previously, configuration with multiple statistics for a single metric would return data for only one of the statistics. e.g.

```
discovery:
- type: elb
  region: ap-southeast-2
  searchTags:
  - Key: Service
    Value: abc
  metrics:
  - name: SurgeQueueLength
    statistics: [Sum, Maximum]
    period: 60
    length: 600
```

```
$ curl -s localhost:5000/metrics | grep surge
# HELP aws_elb_surgequeuelength_maximum Help is not implemented yet.
# TYPE aws_elb_surgequeuelength_maximum gauge
aws_elb_surgequeuelength_maximum{name="arn:aws:elasticloadbalancing:ap-southeast-2:1234567890:loadbalancer/abc"} 1
aws_elb_surgequeuelength_maximum{name="arn:aws:elasticloadbalancing:ap-southeast-2:1234567890:loadbalancer/def"} 1
```

After this change, both statistics are returned:

```
$ curl -s localhost:5000/metrics|grep surge
# HELP aws_elb_surgequeuelength_maximum Help is not implemented yet.
# TYPE aws_elb_surgequeuelength_maximum gauge
aws_elb_surgequeuelength_maximum{name="arn:aws:elasticloadbalancing:ap-southeast-2:1234567890:loadbalancer/abc"} 1
aws_elb_surgequeuelength_maximum{name="arn:aws:elasticloadbalancing:ap-southeast-2:1234567890:loadbalancer/def"} 1
# HELP aws_elb_surgequeuelength_sum Help is not implemented yet.
# TYPE aws_elb_surgequeuelength_sum gauge
aws_elb_surgequeuelength_sum{name="arn:aws:elasticloadbalancing:ap-southeast-2:1234567890:loadbalancer/abc"} 5
aws_elb_surgequeuelength_sum{name="arn:aws:elasticloadbalancing:ap-southeast-2:1234567890:loadbalancer/def"} 43
```