### PR TITLE
Allow setting a role to assume per job

### DIFF
--- a/src/abstract.go
+++ b/src/abstract.go
@@ -20,13 +20,14 @@ func scrapeAwsData(config conf) ([]*tagsData, []*cloudwatchData) {
 		job := config.Discovery.Jobs[i]
 		go func() {
 			region := &job.Region
+			roleArn := job.RoleArn
 
 			clientCloudwatch := cloudwatchInterface{
-				client: createCloudwatchSession(region),
+				client: createCloudwatchSession(region, roleArn),
 			}
 
 			clientTag := tagsInterface{
-				client: createTagSession(region),
+				client: createTagSession(region, roleArn),
 			}
 
 			resources, metrics := scrapeDiscoveryJob(job, config.Discovery.ExportedTagsOnMetrics, clientTag, clientCloudwatch)
@@ -44,9 +45,10 @@ func scrapeAwsData(config conf) ([]*tagsData, []*cloudwatchData) {
 		job := config.Static[i]
 		go func() {
 			region := &job.Region
+			roleArn := job.RoleArn
 
 			clientCloudwatch := cloudwatchInterface{
-				client: createCloudwatchSession(region),
+				client: createCloudwatchSession(region, roleArn),
 			}
 
 			metrics := scrapeStaticJob(job, clientCloudwatch)

--- a/src/aws_cloudwatch.go
+++ b/src/aws_cloudwatch.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
@@ -29,12 +30,16 @@ type cloudwatchData struct {
 	Tags       []tag
 }
 
-func createCloudwatchSession(region *string) *cloudwatch.CloudWatch {
+func createCloudwatchSession(region *string, roleArn string) *cloudwatch.CloudWatch {
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 	}))
+	config := &aws.Config{Region: region}
+	if roleArn != "" {
+		config.Credentials = stscreds.NewCredentials(sess, roleArn)
+	}
 
-	return cloudwatch.New(sess, &aws.Config{Region: region})
+	return cloudwatch.New(sess, config)
 }
 
 func createGetMetricStatisticsInput(dimensions []*cloudwatch.Dimension, namespace *string, metric metric) (output *cloudwatch.GetMetricStatisticsInput) {

--- a/src/aws_tags.go
+++ b/src/aws_tags.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "fmt"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	r "github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi/resourcegroupstaggingapiiface"
@@ -22,13 +23,17 @@ type tagsInterface struct {
 	client resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI
 }
 
-func createTagSession(region *string) *r.ResourceGroupsTaggingAPI {
+func createTagSession(region *string, roleArn string) *r.ResourceGroupsTaggingAPI {
 	sess, err := session.NewSession()
 	if err != nil {
 		panic(err)
 	}
+	config := &aws.Config{Region: region}
+	if roleArn != "" {
+		config.Credentials = stscreds.NewCredentials(sess, roleArn)
+	}
 
-	return r.New(sess, &aws.Config{Region: region})
+	return r.New(sess, config)
 }
 
 func (iface tagsInterface) get(job job) (resources []*tagsData, err error) {

--- a/src/config.go
+++ b/src/config.go
@@ -21,7 +21,7 @@ type exportedTagsOnMetrics map[string][]string
 type job struct {
 	Region     string   `yaml:"region"`
 	Type       string   `yaml:"type"`
-	RoleArn    string   `yaml:"role_arn"`
+	RoleArn    string   `yaml:"roleArn"`
 	SearchTags []tag    `yaml:"searchTags"`
 	Metrics    []metric `yaml:"metrics"`
 }
@@ -29,7 +29,7 @@ type job struct {
 type static struct {
 	Name       string      `yaml:"name"`
 	Region     string      `yaml:"region"`
-	RoleArn    string      `yaml:"role_arn"`
+	RoleArn    string      `yaml:"roleArn"`
 	Namespace  string      `yaml:"namespace"`
 	CustomTags []tag       `yaml:"customTags"`
 	Dimensions []dimension `yaml:"dimensions"`

--- a/src/config.go
+++ b/src/config.go
@@ -21,6 +21,7 @@ type exportedTagsOnMetrics map[string][]string
 type job struct {
 	Region     string   `yaml:"region"`
 	Type       string   `yaml:"type"`
+	RoleArn    string   `yaml:"role_arn"`
 	SearchTags []tag    `yaml:"searchTags"`
 	Metrics    []metric `yaml:"metrics"`
 }
@@ -28,6 +29,7 @@ type job struct {
 type static struct {
 	Name       string      `yaml:"name"`
 	Region     string      `yaml:"region"`
+	RoleArn    string      `yaml:"role_arn"`
 	Namespace  string      `yaml:"namespace"`
 	CustomTags []tag       `yaml:"customTags"`
 	Dimensions []dimension `yaml:"dimensions"`


### PR DESCRIPTION
Adds a new `role_arn` setting to each job to allow scraping multiple targets with
different roles.

This will allow `yace` to pull data from multiple AWS accounts using cross-account roles, or use a different role to scrape instances in the current account.