### PR TITLE
Add snake_case to variable names like prometheus/cloudwatch_exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,17 +138,17 @@ yace_cloudwatch_requests_total 168
 aws_ec2_cpuutilization_average + on (name) group_left(tag_Name) aws_ec2_info
 
 # Free Storage in Megabytes + tag Type of the elasticsearch cluster
-(aws_es_freestoragespace_sum + on (name) group_left(tag_Type) aws_es_info) / 1024
+(aws_es_free_storage_space_sum + on (name) group_left(tag_Type) aws_es_info) / 1024
 
 # Add kubernetes / kops tags on 4xx elb metrics
-(aws_elb_httpcode_backend_4xx_sum + on (name) group_left(tag_KubernetesCluster,tag_kubernetes_io_service_name) aws_elb_info)
+(aws_elb_httpcode_backend_4_xx_sum + on (name) group_left(tag_KubernetesCluster,tag_kubernetes_io_service_name) aws_elb_info)
 
 # Availability Metric for ELBs (Sucessfull requests / Total Requests) + k8s service name
 # Use nilToZero on all metrics else it won't work
-((aws_elb_requestcount_sum - on (name) group_left() aws_elb_httpcode_backend_4xx_sum) - on (name) group_left() aws_elb_httpcode_backend_5xx_sum) + on (name) group_left(tag_kubernetes_io_service_name) aws_elb_info
+((aws_elb_request_count_sum - on (name) group_left() aws_elb_httpcode_backend_4_xx_sum) - on (name) group_left() aws_elb_httpcode_backend_5_xx_sum) + on (name) group_left(tag_kubernetes_io_service_name) aws_elb_info
 
 # Forecast your elasticsearch disk size in 7 days and report metrics with tags type and version
-predict_linear(aws_es_freestoragespace_minimum[2d], 86400 * 7) + on (name) group_left(tag_type, tag_version) aws_es_info
+predict_linear(aws_es_free_storage_space_minimum[2d], 86400 * 7) + on (name) group_left(tag_type, tag_version) aws_es_info
 
 # Forecast your cloudwatch costs for next 32 days based on last 10 minutes
 # 1.000.000 Requests free

--- a/src/aws_cloudwatch.go
+++ b/src/aws_cloudwatch.go
@@ -301,7 +301,7 @@ func migrateCloudwatchToPrometheus(cwd []*cloudwatchData) []*prometheusData {
 					promLabels["custom_tag_"+label.Key] = label.Value
 				}
 				for _, tag := range c.Tags {
-					promLabels["tag_"+promString(tag.Key)] = tag.Value
+					promLabels["tag_"+promStringTag(tag.Key)] = tag.Value
 				}
 
 				var value float64 = 0

--- a/src/aws_tags.go
+++ b/src/aws_tags.go
@@ -126,7 +126,7 @@ func migrateTagsToPrometheus(tagData []*tagsData) []*prometheusData {
 		promLabels["name"] = *d.ID
 
 		for _, entry := range tagList[*d.Service] {
-			labelKey := "tag_" + promString(entry)
+			labelKey := "tag_" + promStringTag(entry)
 			promLabels[labelKey] = ""
 
 			for _, rTag := range d.Tags {

--- a/src/prometheus.go
+++ b/src/prometheus.go
@@ -64,12 +64,20 @@ func fillRegistry(promData []*prometheusData) *prometheus.Registry {
 }
 
 func promString(text string) string {
-	text = splitText(text)
+	text = splitString(text)
+	return replaceWithUnderscores(text)
+}
+
+func promStringTag(text string) string {
+	return replaceWithUnderscores(text)
+}
+
+func replaceWithUnderscores(text string) string {
 	replacer := strings.NewReplacer(" ", "_", ",", "_", "\t", "_", ",", "_", "/", "_", "\\", "_", ".", "_", "-", "_", ":", "_")
 	return replacer.Replace(text)
 }
 
-func splitText(text string) string {
+func splitString(text string) string {
 	splitRegexp := regexp.MustCompile(`([a-z0-9])([A-Z])`)
 	return splitRegexp.ReplaceAllString(text, `$1.$2`)
 }

--- a/src/prometheus.go
+++ b/src/prometheus.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"github.com/prometheus/client_golang/prometheus"
+	"regexp"
 	"strings"
 )
 

--- a/src/prometheus.go
+++ b/src/prometheus.go
@@ -69,6 +69,6 @@ func promString(text string) string {
 }
 
 func splitText(text string) string {
-	split_regexp := regexp.MustCompile(`([a-z0-9])([A-Z])`)
-	return split_regexp.ReplaceAllString(text, `$1.$2`)
+	splitRegexp := regexp.MustCompile(`([a-z0-9])([A-Z])`)
+	return splitRegexp.ReplaceAllString(text, `$1.$2`)
 }

--- a/src/prometheus.go
+++ b/src/prometheus.go
@@ -63,6 +63,12 @@ func fillRegistry(promData []*prometheusData) *prometheus.Registry {
 }
 
 func promString(text string) string {
+	text = splitText(text)
 	replacer := strings.NewReplacer(" ", "_", ",", "_", "\t", "_", ",", "_", "/", "_", "\\", "_", ".", "_", "-", "_", ":", "_")
 	return replacer.Replace(text)
+}
+
+func splitText(text string) string {
+	split_regexp := regexp.MustCompile(`([a-z0-9])([A-Z])`)
+	return split_regexp.ReplaceAllString(text, `$1.$2`)
 }


### PR DESCRIPTION
Hi!

**prometheus/cloudwatch_exporter** exports the metric_names with underscores, for example for ELB RequestCount, currently we are exporting it like:

`aws_elb_requestcount_sum`
instead of:
`aws_elb_request_count_sum`

Some projects like gitlab, use underscores with queries because it's like the "official" one

That piece of code transforms names to snake_case

Example:

```
# HELP aws_elb_httpcode_backend_4_xx_sum Help is not implemented yet.
# TYPE aws_elb_httpcode_backend_4_xx_sum gauge
aws_elb_httpcode_backend_4_xx_sum{Name="test-elb",environment="test-elb-ppnamx"} 0
# HELP aws_elb_httpcode_backend_5_xx_sum Help is not implemented yet.
# TYPE aws_elb_httpcode_backend_5_xx_sum gauge
aws_elb_httpcode_backend_5_xx_sum{Name="test-elb",environment="test-elb-ppnamx"} 0
# HELP aws_elb_request_count_sum Help is not implemented yet.
# TYPE aws_elb_request_count_sum gauge
aws_elb_request_count_sum{Name="test-elb",environment="test-elb-ppnamx"} 5
# HELP yace_cloudwatch_requests_total Help is not implemented yet.
# TYPE yace_cloudwatch_requests_total counter
yace_cloudwatch_requests_total 4
```