### PR TITLE
#46 Add ability to specify dimensions on discovery jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ YACE is currently in quick iteration mode. Things will probably break in upcomin
 * Allows to export 0 even if CloudWatch returns nil
 * Exports metrics with CloudWatch timestamps (can be disabled per-metric)
 * Static metrics support for all cloudwatch metrics without auto discovery
-* Pull data from mulitple AWS accounts using cross-acount roles
+* Pull data from multiple AWS accounts using cross-account roles
 * Supported services with auto discovery through tags:
   - alb - Application Load Balancer
   - ebs - Elastic Block Storage
@@ -57,13 +57,14 @@ exportedTagsOnMetrics:
 
 ### Auto-discovery job
 
-| Key        | Description                                                                              |
-| ---------- | ---------------------------------------------------------------------------------------- |
-| region     | AWS region                                                                               |
-| type       | Service name, e.g. "ec2", "s3", etc.                                                     |
-| roleArn    | IAM role to assume (optional)                                                            |
-| searchTags | List of Key/Value pairs to use for tag filtering (all must match), Value can be a regex. |
-| metrics    | List of metric definitions                                                               |
+| Key                  | Description                                                                              |
+| -------------------- | ---------------------------------------------------------------------------------------- |
+| region               | AWS region                                                                               |
+| type                 | Service name, e.g. "ec2", "s3", etc.                                                     |
+| roleArn              | IAM role to assume (optional)                                                            |
+| searchTags           | List of Key/Value pairs to use for tag filtering (all must match), Value can be a regex. |
+| metrics              | List of metric definitions                                                               |
+| additionalDimensions | List of dimensions to return beyond the default list per service                         |
 
 searchTags example:
 ```
@@ -78,11 +79,12 @@ searchTags:
 | ---------------- | -------------------------------------------------------------------------------------------------------- |
 | name             | CloudWatch metric name                                                                                   |
 | statistics       | List of statictic types, e.g. "Mininum", "Maximum", etc.                                                 |
-| period           | Statictic period                                                                                         |
+| period           | Statistic period                                                                                         |
 | length           | How far back to request data for                                                                         |
 | delay            | If set it will request metrics up until `current_time - delay`                                           |
 | nilToZero        | Return 0 value if Cloudwatch returns no metrics at all                                                   |
 | disableTimestamp | Do not export the metric with the original CloudWatch timestamp (useful for sparse metrics, e.g from S3) |
+
 
 ### Static configuration
 
@@ -180,8 +182,17 @@ discovery:
     searchTags:
       - Key: type
         Value: public
+    additionalDimensions:
+      - name: StorageType
+        value: StandardStorage
     metrics:
       - name: NumberOfObjects
+        statistics:
+          - Average
+        period: 86400
+        length: 172800
+        disableTimestamp: true
+      - name: BucketSizeBytes
         statistics:
           - Average
         period: 86400

--- a/src/abstract.go
+++ b/src/abstract.go
@@ -117,9 +117,9 @@ func scrapeDiscoveryJob(job job, tagsOnMetrics exportedTagsOnMetrics, clientTag 
 
 		wg.Add(len(job.Metrics))
 		go func() {
-			dimensions := getDimensions(resource.Service, resource.ID, clientCloudwatch)
 			for j := range job.Metrics {
 				metric := job.Metrics[j]
+				dimensions := getDimensions(resource.Service, resource.ID, metric.Dimensions, clientCloudwatch)
 				go func() {
 					data := cloudwatchData{
 						ID:               resource.ID,

--- a/src/abstract.go
+++ b/src/abstract.go
@@ -119,7 +119,8 @@ func scrapeDiscoveryJob(job job, tagsOnMetrics exportedTagsOnMetrics, clientTag 
 		go func() {
 			for j := range job.Metrics {
 				metric := job.Metrics[j]
-				dimensions := getDimensions(resource.Service, resource.ID, metric.Dimensions, clientCloudwatch)
+				dimensions := detectDimensionsByService(resource.Service, resource.ID, clientCloudwatch)
+				dimensions = addAdditionalDimensions(dimensions, metric.AdditionalDimensions)
 				go func() {
 					data := cloudwatchData{
 						ID:               resource.ID,

--- a/src/aws_cloudwatch.go
+++ b/src/aws_cloudwatch.go
@@ -225,6 +225,9 @@ func getDimensions(service *string, resourceArn *string, configuredDimensions []
 		dimensions = append(dimensions, buildDimension("ClientId", arnParsed.AccountID))
 	case "s3":
 		dimensions = buildBaseDimension(arnParsed.Resource, "BucketName", "")
+		if len(configuredDimensions) == 0 {
+			dimensions = append(dimensions, buildDimension("StorageType", "AllStorageTypes"))
+		}
 	case "efs":
 		dimensions = buildBaseDimension(arnParsed.Resource, "FileSystemId", "file-system/")
 	case "ebs":

--- a/src/aws_cloudwatch.go
+++ b/src/aws_cloudwatch.go
@@ -202,7 +202,7 @@ func queryAvailableDimensions(resource string, namespace *string, clientCloudwat
 	return dimensions
 }
 
-func getDimensions(service *string, resourceArn *string, clientCloudwatch cloudwatchInterface) (dimensions []*cloudwatch.Dimension) {
+func getDimensions(service *string, resourceArn *string, configuredDimensions []dimension, clientCloudwatch cloudwatchInterface) (dimensions []*cloudwatch.Dimension) {
 	arnParsed, err := arn.Parse(*resourceArn)
 
 	if err != nil {
@@ -225,7 +225,6 @@ func getDimensions(service *string, resourceArn *string, clientCloudwatch cloudw
 		dimensions = append(dimensions, buildDimension("ClientId", arnParsed.AccountID))
 	case "s3":
 		dimensions = buildBaseDimension(arnParsed.Resource, "BucketName", "")
-		dimensions = append(dimensions, buildDimension("StorageType", "AllStorageTypes"))
 	case "efs":
 		dimensions = buildBaseDimension(arnParsed.Resource, "FileSystemId", "file-system/")
 	case "ebs":
@@ -239,6 +238,11 @@ func getDimensions(service *string, resourceArn *string, clientCloudwatch cloudw
 	default:
 		log.Fatal("Not implemented cloudwatch metric: " + *service)
 	}
+
+	for _, dimension := range configuredDimensions {
+		dimensions = append(dimensions, buildDimension(dimension.Name, dimension.Value))
+	}
+
 	return dimensions
 }
 

--- a/src/config.go
+++ b/src/config.go
@@ -38,13 +38,14 @@ type static struct {
 }
 
 type metric struct {
-	Name             string   `yaml:"name"`
-	Statistics       []string `yaml:"statistics"`
-	Period           int      `yaml:"period"`
-	Length           int      `yaml:"length"`
-	Delay            int      `yaml:"delay"`
-	NilToZero        bool     `yaml:"nilToZero"`
-	DisableTimestamp bool     `yaml:"disableTimestamp"`
+	Name             string      `yaml:"name"`
+	Statistics       []string    `yaml:"statistics"`
+	Dimensions       []dimension `yaml:"dimensions"`
+	Period           int         `yaml:"period"`
+	Length           int         `yaml:"length"`
+	Delay            int         `yaml:"delay"`
+	NilToZero        bool        `yaml:"nilToZero"`
+	DisableTimestamp bool        `yaml:"disableTimestamp"`
 }
 
 type dimension struct {

--- a/src/config.go
+++ b/src/config.go
@@ -38,14 +38,14 @@ type static struct {
 }
 
 type metric struct {
-	Name             string      `yaml:"name"`
-	Statistics       []string    `yaml:"statistics"`
-	Dimensions       []dimension `yaml:"dimensions"`
-	Period           int         `yaml:"period"`
-	Length           int         `yaml:"length"`
-	Delay            int         `yaml:"delay"`
-	NilToZero        bool        `yaml:"nilToZero"`
-	DisableTimestamp bool        `yaml:"disableTimestamp"`
+	Name                  string      `yaml:"name"`
+	Statistics            []string    `yaml:"statistics"`
+	AdditionalDimensions	[]dimension `yaml:"additionalDimensions"`
+	Period                int         `yaml:"period"`
+	Length                int         `yaml:"length"`
+	Delay                 int         `yaml:"delay"`
+	NilToZero             bool        `yaml:"nilToZero"`
+	DisableTimestamp      bool        `yaml:"disableTimestamp"`
 }
 
 type dimension struct {


### PR DESCRIPTION
Added the ability to specify dimensions for discovered jobs.

This solved my issue with getting the BucketSizeBytes metric for S3. Note that I don't really know Go, so I didn't try to solve the backwards compatibility issue around the old behavior of adding that one default metric to all S3 queries since I wasn't sure whether you wanted to keep that as a default fallback or not.