### PR TITLE
when the resource string has prefix as targetgroup/ then no need to trim for prefix /loadbalancer     

### DIFF
--- a/src/aws_cloudwatch.go
+++ b/src/aws_cloudwatch.go
@@ -213,8 +213,7 @@ func queryAvailableDimensions(resource string, namespace *string, clientCloudwat
 		dimensions = append(dimensions, buildDimension("TargetGroup", resource))
 		loadBalancerName := getResourceValue("LoadBalancer", dimensions, namespace, clientCloudwatch)
 		if loadBalancerName != nil {
-			trimmedDimensionValue := strings.Replace(resource, "loadbalancer/", "", -1)
-			dimensions = append(dimensions, buildDimension("LoadBalancer", trimmedDimensionValue))
+			dimensions = append(dimensions, buildDimension("LoadBalancer", *loadBalancerName))
 		}
 
 	} else if strings.HasPrefix(resource, "loadbalancer/") || strings.HasPrefix(resource, "app/") {


### PR DESCRIPTION
This was done by mistake from my side that instead of trimming "/loadbalancer"  in "else if" condition i did this trimming in "if" condition part which checks for prefix as "/targetgroup". While creating this diff by mistake I added the trimmed logic in "if" condition instead of adding it "else if" condition. For this you have made the relevant changes in
[963942f]( https://github.com/ivx/yet-another-cloudwatch-exporter/commit/963942f6aa98d93c49a9b5e0a7b05fa9fbac2e44)

Removed the unnecessary part.

Really sorry for this silly mistake from my side.