### PR TITLE
Add support for retrieving ASG metrics based on tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ YACE is currently in quick iteration mode. Things will probably break in upcomin
   - rds - Relational Database Service
   - s3 - Object Storage
   - vpn - VPN connection
+  - asg - Auto Scaling Group
 
 ## Image
 * `quay.io/invisionag/yet-another-cloudwatch-exporter:x.x.x` e.g. 0.5.0

--- a/abstract.go
+++ b/abstract.go
@@ -27,7 +27,8 @@ func scrapeAwsData(config conf) ([]*tagsData, []*cloudwatchData) {
 			}
 
 			clientTag := tagsInterface{
-				client: createTagSession(region, roleArn),
+				client:    createTagSession(region, roleArn),
+				asgClient: createASGSession(region, roleArn),
 			}
 
 			resources, metrics := scrapeDiscoveryJob(job, config.Discovery.ExportedTagsOnMetrics, clientTag, clientCloudwatch)

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -166,6 +166,8 @@ func getNamespace(service *string) *string {
 		ns = "AWS/Kinesis"
 	case "dynamodb":
 		ns = "AWS/DynamoDB"
+	case "asg":
+		ns = "AWS/AutoScaling"
 	default:
 		log.Fatal("Not implemented namespace for cloudwatch metric: " + *service)
 	}
@@ -263,6 +265,8 @@ func detectDimensionsByService(service *string, resourceArn *string, clientCloud
 		dimensions = buildBaseDimension(arnParsed.Resource, "StreamName", "stream/")
 	case "dynamodb":
 		dimensions = buildBaseDimension(arnParsed.Resource, "TableName", "table/")
+	case "asg":
+		dimensions = buildBaseDimension(arnParsed.Resource, "AutoScalingGroupName", "autoScalingGroupName/")
 	default:
 		log.Fatal("Not implemented cloudwatch metric: " + *service)
 	}

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ var (
 		"s3",
 		"kinesis",
 		"vpn",
+		"asg",
 	}
 
 	config = conf{}


### PR DESCRIPTION
Whilst evaluating tools to allow the monitoring & alerting of various CloudWatch metrics through Prometheus, I noticed that this tool doesn't support being able to discover metrics from autoscaling groups automatically due to the fact that the resourcegrouptaggingapi doesn't support ASGs.

This change works around the limitation in the resourcegrouptaggingapi by using the ASG API to discover groups as required.