### PR TITLE
Fix illegal tag character replacement, add cURL to container, and add EBS example to readme.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN go build -v -ldflags "-X main.version=$VERSION" -o yace
 
 FROM alpine:latest
 
-RUN apk --no-cache add ca-certificates
+RUN apk --no-cache add ca-certificates curl
 WORKDIR /root/
 COPY --from=builder /opt/yace /usr/local/bin/yace
 CMD ["/usr/local/bin/yace"]

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ discovery:
   exportedTagsOnMetrics:
     ec2:
       - Name
+    ebs:
+      - VolumeId
   jobs:
   - region: eu-west-1
     type: "es"
@@ -201,6 +203,17 @@ discovery:
         period: 86400
         length: 172800
         addCloudwatchTimestamp: true
+  - type: "ebs"
+    region: us-east-1
+    searchTags:
+      - Key: type
+        Value: public
+    metrics:
+      - name: BurstBalance
+        statistics:
+        - 'Minimum'
+        period: 600
+        length: 600
 static:
   - namespace: AWS/AutoScaling
     region: eu-west-1

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ discovery:
         length: 172800
         addCloudwatchTimestamp: true
   - type: "ebs"
-    region: us-east-1
+    region: eu-west-1
     searchTags:
       - Key: type
         Value: public

--- a/prometheus.go
+++ b/prometheus.go
@@ -93,7 +93,7 @@ func promStringTag(text string) string {
 }
 
 func replaceWithUnderscores(text string) string {
-	replacer := strings.NewReplacer(" ", "_", ",", "_", "\t", "_", ",", "_", "/", "_", "\\", "_", ".", "_", "-", "_", ":", "_")
+	replacer := strings.NewReplacer(" ", "_", ",", "_", "\t", "_", ",", "_", "/", "_", "\\", "_", ".", "_", "-", "_", ":", "_", "=", "_")
 	return replacer.Replace(text)
 }
 


### PR DESCRIPTION
While trying to setup YACE, we found that one of our EBS volumes had a tag which contained an equals sign, "=", which YACE was reporting as illegal and crashing on. I've updated this replacement command to now handle equals signs as expected.

I've also added a bit to the README.md file that shows some basic EBS configuration to get "BurstBalance" stats from those EBS volumes, since EBS isn't covered by the default example configuration.

I've also added the installation of cURL to the container's Dockerfile to assist with troubleshooting.