### PR TITLE
WIP | adding awsDimension variable in config to fanout additional dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,6 @@ discovery:
         length: 60
   - type: elb
     region: eu-west-1
-    cloudWatchMaxRetries: 0
     awsDimensions:
      - AvailabilityZone
     searchTags:

--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ discovery:
         length: 60
   - type: elb
     region: eu-west-1
+    cloudWatchMaxRetries: 0
+    awsDimensions:
+     - AvailabilityZone
     searchTags:
       - Key: KubernetesCluster
         Value: production-19

--- a/abstract.go
+++ b/abstract.go
@@ -27,9 +27,10 @@ func scrapeAwsData(config conf) ([]*tagsData, []*cloudwatchData) {
 		go func() {
 			region := &job.Region
 			roleArn := job.RoleArn
+			maxRetries := job.CloudWatchMaxRetries
 
 			clientCloudwatch := cloudwatchInterface{
-				client: createCloudwatchSession(region, roleArn),
+				client: createCloudwatchSession(region, roleArn, maxRetries),
 			}
 
 			clientTag := tagsInterface{
@@ -53,9 +54,10 @@ func scrapeAwsData(config conf) ([]*tagsData, []*cloudwatchData) {
 		go func() {
 			region := &job.Region
 			roleArn := job.RoleArn
+			maxRetries := job.CloudWatchMaxRetries
 
 			clientCloudwatch := cloudwatchInterface{
-				client: createCloudwatchSession(region, roleArn),
+				client: createCloudwatchSession(region, roleArn, maxRetries),
 			}
 
 			metrics := scrapeStaticJob(job, clientCloudwatch)

--- a/abstract.go
+++ b/abstract.go
@@ -156,19 +156,6 @@ func scrapeDiscoveryJob(job job, tagsOnMetrics exportedTagsOnMetrics, clientTag 
 					defer func() {
 						<-cloudwatchSemaphore
 					}()
-<<<<<<< HEAD
-
-					data := cloudwatchData{
-						ID:                     resource.ID,
-						Metric:                 &metric.Name,
-						Service:                resource.Service,
-						Statistics:             metric.Statistics,
-						NilToZero:              &metric.NilToZero,
-						AddCloudwatchTimestamp: &metric.AddCloudwatchTimestamp,
-						Tags:                   metricTags,
-						Dimensions:             dimensions,
-						Region:                 &job.Region,
-=======
 					for _, fetchedMetrics := range resp.Metrics {
 
 						data := cloudwatchData{
@@ -180,6 +167,7 @@ func scrapeDiscoveryJob(job job, tagsOnMetrics exportedTagsOnMetrics, clientTag 
 							AddCloudwatchTimestamp: &metric.AddCloudwatchTimestamp,
 							Tags:                   metricTags,
 							Dimensions:             fetchedMetrics.Dimensions,
+							Region:                 &job.Region,
 						}
 
 						filter := createGetMetricStatisticsInput(
@@ -190,7 +178,6 @@ func scrapeDiscoveryJob(job job, tagsOnMetrics exportedTagsOnMetrics, clientTag 
 
 						data.Points = clientCloudwatch.get(filter)
 						cw = append(cw, &data)
->>>>>>> adding awsDimension variable in config to fanout additional dimensions
 					}
 					mux.Lock()
 					mux.Unlock()

--- a/abstract.go
+++ b/abstract.go
@@ -27,10 +27,9 @@ func scrapeAwsData(config conf) ([]*tagsData, []*cloudwatchData) {
 		go func() {
 			region := &job.Region
 			roleArn := job.RoleArn
-			maxRetries := job.CloudWatchMaxRetries
 
 			clientCloudwatch := cloudwatchInterface{
-				client: createCloudwatchSession(region, roleArn, maxRetries),
+				client: createCloudwatchSession(region, roleArn),
 			}
 
 			clientTag := tagsInterface{
@@ -54,10 +53,9 @@ func scrapeAwsData(config conf) ([]*tagsData, []*cloudwatchData) {
 		go func() {
 			region := &job.Region
 			roleArn := job.RoleArn
-			maxRetries := job.CloudWatchMaxRetries
 
 			clientCloudwatch := cloudwatchInterface{
-				client: createCloudwatchSession(region, roleArn, maxRetries),
+				client: createCloudwatchSession(region, roleArn),
 			}
 
 			metrics := scrapeStaticJob(job, clientCloudwatch)

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -38,7 +38,7 @@ type cloudwatchData struct {
 	Region                 *string
 }
 
-func createCloudwatchSession(region *string, roleArn string, maxRetries int) *cloudwatch.CloudWatch {
+func createCloudwatchSession(region *string, roleArn string) *cloudwatch.CloudWatch {
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 	}))
@@ -395,6 +395,7 @@ func migrateCloudwatchToPrometheus(cwd []*cloudwatchData) []*PrometheusMetric {
 	for _, c := range cwd {
 		for _, statistic := range c.Statistics {
 			name := "aws_" + fixServiceName(c.Service, c.Dimensions) + "_" + strings.ToLower(promString(*c.Metric)) + "_" + strings.ToLower(promString(statistic))
+<<<<<<< HEAD
 
 			datapoints := c.Points
 			// sorting by timestamps so we can consistently export the most updated datapoint
@@ -403,11 +404,22 @@ func migrateCloudwatchToPrometheus(cwd []*cloudwatchData) []*PrometheusMetric {
 				jTimestamp := *datapoints[j].Timestamp
 				return datapoints[i].Timestamp.Before(jTimestamp)
 			})
+=======
+			var points []*float64
+>>>>>>> adding awsDimension variable in config to fanout additional dimensions
 
 			var exportedDatapoint *float64
 			var averageDataPoints []*float64
 			var timestamp time.Time
+<<<<<<< HEAD
 			for _, datapoint := range datapoints {
+=======
+			for _, point := range c.Points {
+				if point.Timestamp != nil && timestamp.Before(*point.Timestamp) {
+					timestamp = *point.Timestamp
+				}
+
+>>>>>>> adding awsDimension variable in config to fanout additional dimensions
 				switch {
 				case statistic == "Maximum":
 					if datapoint.Maximum != nil {

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -372,15 +372,22 @@ func buildDimension(key string, value string) *cloudwatch.Dimension {
 }
 
 func fixServiceName(serviceName *string, dimensions []*cloudwatch.Dimension) string {
-	var targetGroup string
+	var suffixName string
 	if *serviceName == "alb" {
 		for _, dimension := range dimensions {
 			if *dimension.Name == "TargetGroup" {
-				targetGroup = "tg"
+				suffixName = "tg"
 			}
 		}
 	}
-	return strings.ToLower(promString(*serviceName)) + targetGroup
+	if *serviceName == "elb" {
+		for _, dimension := range dimensions {
+			if *dimension.Name == "AvailabilityZone" {
+				suffixName = "_az"
+			}
+		}
+	}
+	return strings.ToLower(promString(*serviceName)) + suffixName
 }
 
 func migrateCloudwatchToPrometheus(cwd []*cloudwatchData) []*PrometheusMetric {

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -38,7 +38,7 @@ type cloudwatchData struct {
 	Region                 *string
 }
 
-func createCloudwatchSession(region *string, roleArn string) *cloudwatch.CloudWatch {
+func createCloudwatchSession(region *string, roleArn string, maxRetries int) *cloudwatch.CloudWatch {
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 	}))
@@ -388,7 +388,6 @@ func migrateCloudwatchToPrometheus(cwd []*cloudwatchData) []*PrometheusMetric {
 	for _, c := range cwd {
 		for _, statistic := range c.Statistics {
 			name := "aws_" + fixServiceName(c.Service, c.Dimensions) + "_" + strings.ToLower(promString(*c.Metric)) + "_" + strings.ToLower(promString(statistic))
-<<<<<<< HEAD
 
 			datapoints := c.Points
 			// sorting by timestamps so we can consistently export the most updated datapoint
@@ -397,22 +396,11 @@ func migrateCloudwatchToPrometheus(cwd []*cloudwatchData) []*PrometheusMetric {
 				jTimestamp := *datapoints[j].Timestamp
 				return datapoints[i].Timestamp.Before(jTimestamp)
 			})
-=======
-			var points []*float64
->>>>>>> adding awsDimension variable in config to fanout additional dimensions
 
 			var exportedDatapoint *float64
 			var averageDataPoints []*float64
 			var timestamp time.Time
-<<<<<<< HEAD
 			for _, datapoint := range datapoints {
-=======
-			for _, point := range c.Points {
-				if point.Timestamp != nil && timestamp.Before(*point.Timestamp) {
-					timestamp = *point.Timestamp
-				}
-
->>>>>>> adding awsDimension variable in config to fanout additional dimensions
 				switch {
 				case statistic == "Maximum":
 					if datapoint.Maximum != nil {

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -395,7 +395,6 @@ func migrateCloudwatchToPrometheus(cwd []*cloudwatchData) []*PrometheusMetric {
 	for _, c := range cwd {
 		for _, statistic := range c.Statistics {
 			name := "aws_" + fixServiceName(c.Service, c.Dimensions) + "_" + strings.ToLower(promString(*c.Metric)) + "_" + strings.ToLower(promString(statistic))
-<<<<<<< HEAD
 
 			datapoints := c.Points
 			// sorting by timestamps so we can consistently export the most updated datapoint
@@ -404,22 +403,11 @@ func migrateCloudwatchToPrometheus(cwd []*cloudwatchData) []*PrometheusMetric {
 				jTimestamp := *datapoints[j].Timestamp
 				return datapoints[i].Timestamp.Before(jTimestamp)
 			})
-=======
-			var points []*float64
->>>>>>> adding awsDimension variable in config to fanout additional dimensions
 
 			var exportedDatapoint *float64
 			var averageDataPoints []*float64
 			var timestamp time.Time
-<<<<<<< HEAD
 			for _, datapoint := range datapoints {
-=======
-			for _, point := range c.Points {
-				if point.Timestamp != nil && timestamp.Before(*point.Timestamp) {
-					timestamp = *point.Timestamp
-				}
-
->>>>>>> adding awsDimension variable in config to fanout additional dimensions
 				switch {
 				case statistic == "Maximum":
 					if datapoint.Maximum != nil {

--- a/config.go
+++ b/config.go
@@ -21,24 +21,22 @@ type discovery struct {
 type exportedTagsOnMetrics map[string][]string
 
 type job struct {
-	Region               string   `yaml:"region"`
-	Type                 string   `yaml:"type"`
-	RoleArn              string   `yaml:"roleArn"`
-	AwsDimensions        []string `yaml:"awsDimensions"`
-	SearchTags           []tag    `yaml:"searchTags"`
-	Metrics              []metric `yaml:"metrics"`
-	CloudWatchMaxRetries int      `yaml:"cloudWatchMaxRetries"`
+	Region        string   `yaml:"region"`
+	Type          string   `yaml:"type"`
+	RoleArn       string   `yaml:"roleArn"`
+	AwsDimensions []string `yaml:"awsDimensions"`
+	SearchTags    []tag    `yaml:"searchTags"`
+	Metrics       []metric `yaml:"metrics"`
 }
 
 type static struct {
-	Name                 string      `yaml:"name"`
-	Region               string      `yaml:"region"`
-	RoleArn              string      `yaml:"roleArn"`
-	Namespace            string      `yaml:"namespace"`
-	CustomTags           []tag       `yaml:"customTags"`
-	Dimensions           []dimension `yaml:"dimensions"`
-	Metrics              []metric    `yaml:"metrics"`
-	CloudWatchMaxRetries int         `yaml:"cloudWatchMaxRetries"`
+	Name       string      `yaml:"name"`
+	Region     string      `yaml:"region"`
+	RoleArn    string      `yaml:"roleArn"`
+	Namespace  string      `yaml:"namespace"`
+	CustomTags []tag       `yaml:"customTags"`
+	Dimensions []dimension `yaml:"dimensions"`
+	Metrics    []metric    `yaml:"metrics"`
 }
 
 type metric struct {

--- a/config.go
+++ b/config.go
@@ -21,22 +21,24 @@ type discovery struct {
 type exportedTagsOnMetrics map[string][]string
 
 type job struct {
-	Region        string   `yaml:"region"`
-	Type          string   `yaml:"type"`
-	RoleArn       string   `yaml:"roleArn"`
-	AwsDimensions []string `yaml:"awsDimensions"`
-	SearchTags    []tag    `yaml:"searchTags"`
-	Metrics       []metric `yaml:"metrics"`
+	Region               string   `yaml:"region"`
+	Type                 string   `yaml:"type"`
+	RoleArn              string   `yaml:"roleArn"`
+	AwsDimensions        []string `yaml:"awsDimensions"`
+	SearchTags           []tag    `yaml:"searchTags"`
+	Metrics              []metric `yaml:"metrics"`
+	CloudWatchMaxRetries int      `yaml:"cloudWatchMaxRetries"`
 }
 
 type static struct {
-	Name       string      `yaml:"name"`
-	Region     string      `yaml:"region"`
-	RoleArn    string      `yaml:"roleArn"`
-	Namespace  string      `yaml:"namespace"`
-	CustomTags []tag       `yaml:"customTags"`
-	Dimensions []dimension `yaml:"dimensions"`
-	Metrics    []metric    `yaml:"metrics"`
+	Name                 string      `yaml:"name"`
+	Region               string      `yaml:"region"`
+	RoleArn              string      `yaml:"roleArn"`
+	Namespace            string      `yaml:"namespace"`
+	CustomTags           []tag       `yaml:"customTags"`
+	Dimensions           []dimension `yaml:"dimensions"`
+	Metrics              []metric    `yaml:"metrics"`
+	CloudWatchMaxRetries int         `yaml:"cloudWatchMaxRetries"`
 }
 
 type metric struct {

--- a/config.go
+++ b/config.go
@@ -21,11 +21,12 @@ type discovery struct {
 type exportedTagsOnMetrics map[string][]string
 
 type job struct {
-	Region     string   `yaml:"region"`
-	Type       string   `yaml:"type"`
-	RoleArn    string   `yaml:"roleArn"`
-	SearchTags []tag    `yaml:"searchTags"`
-	Metrics    []metric `yaml:"metrics"`
+	Region        string   `yaml:"region"`
+	Type          string   `yaml:"type"`
+	RoleArn       string   `yaml:"roleArn"`
+	AwsDimensions []string `yaml:"awsDimensions"`
+	SearchTags    []tag    `yaml:"searchTags"`
+	Metrics       []metric `yaml:"metrics"`
 }
 
 type static struct {
@@ -68,7 +69,6 @@ func (c *conf) load(file *string) error {
 	if err != nil {
 		return err
 	}
-
 	for _, job := range c.Discovery.Jobs {
 		if !stringInSlice(job.Type, supportedServices) {
 			return fmt.Errorf("Service is not in known list!: %v", job.Type)

--- a/prometheus.go
+++ b/prometheus.go
@@ -29,7 +29,8 @@ type PrometheusCollector struct {
 
 func NewPrometheusCollector(metrics []*PrometheusMetric) *PrometheusCollector {
 	return &PrometheusCollector{
-		metrics: removeDuplicatedMetrics(metrics),
+		//metrics: removeDuplicatedMetrics(metrics),
+		metrics: metrics,
 	}
 }
 


### PR DESCRIPTION
awsDimension variable works at job level

```
discovery:
  jobs:
  - type: "elb"
    cloudWatchMaxRetries: 5
    searchTags:
    - Key: kubernetes.io/service-name
      Value: ".*"
    awsDimensions:
    - AvailabilityZone
    region: ap-south-1
    metrics:
      - name: HealthyHostCount
        statistics:
        - 'Minimum'
        period: 60
        length: 60
        delay: 120
      - name: UnHealthyHostCount
        statistics:
        - 'Maximum'
        period: 60
        length: 60
        delay: 120
      - name: RequestCount
        statistics:
        - 'Sum'
        period: 60
        length: 60
        delay: 120
        nilToZero: true
```
for each resource we will make one list metrics api call with filtered dimension. which will contain default dimension(like the loadbalancer name with value) and awsDimension(which will consist of keys) and additionalDimension if specified 