### PR TITLE
fix for concurrency of aws requests

### DIFF
--- a/abstract.go
+++ b/abstract.go
@@ -9,8 +9,8 @@ import (
 )
 
 var (
-	cloudwatchSemaphore = make(chan struct{}, 5)
-	tagSemaphore        = make(chan struct{}, 5)
+	cloudwatchSemaphore = make(chan struct{}, 20)
+	tagSemaphore        = make(chan struct{}, 20)
 )
 
 func scrapeAwsData(config conf) ([]*tagsData, []*cloudwatchData) {


### PR DESCRIPTION
fix for concurrency of aws requests: channel should be acquired outside gorutine. 
Also, increased the number of concurrent requests to 20. Probably we need to think and make this parameter configurable 