### PR TITLE
Fix dimension labels for static Jobs.

### DIFF
--- a/abstract.go
+++ b/abstract.go
@@ -96,11 +96,12 @@ func scrapeStaticJob(resource static, clientCloudwatch cloudwatchInterface) (cw 
 				NilToZero:              &metric.NilToZero,
 				AddCloudwatchTimestamp: &metric.AddCloudwatchTimestamp,
 				CustomTags:             resource.CustomTags,
+				Dimensions:             createStaticDimensions(resource.Dimensions),
 				Region:                 &resource.Region,
 			}
 
 			filter := createGetMetricStatisticsInput(
-				createStaticDimensions(resource.Dimensions),
+				data.Dimensions,
 				&resource.Namespace,
 				metric,
 			)


### PR DESCRIPTION
The dimensions weren't being included in the returned data from
scrapeStaticJob, and therefore weren't being set as labels in the
metrics output.

Fixes #75