### PR TITLE
Add support for SQS queues

### DIFF
--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -171,6 +171,8 @@ func getNamespace(service *string) *string {
 		ns = "AWS/ElasticMapReduce"
 	case "asg":
 		ns = "AWS/AutoScaling"
+	case "sqs":
+		ns = "AWS/SQS"
 	default:
 		log.Fatal("Not implemented namespace for cloudwatch metric: " + *service)
 	}
@@ -272,6 +274,8 @@ func detectDimensionsByService(service *string, resourceArn *string, clientCloud
 		dimensions = buildBaseDimension(arnParsed.Resource, "JobFlowId", "cluster/")
 	case "asg":
 		dimensions = buildBaseDimension(arnParsed.Resource, "AutoScalingGroupName", "autoScalingGroupName/")
+	case "sqs":
+		dimensions = buildBaseDimension(arnParsed.Resource, "QueueName", "")
 	default:
 		log.Fatal("Not implemented cloudwatch metric: " + *service)
 	}

--- a/aws_tags.go
+++ b/aws_tags.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"fmt"
 	_ "fmt"
-	"github.com/aws/aws-sdk-go/service/autoscaling"
-	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
 	"log"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
 	r "github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi/resourcegroupstaggingapiiface"
 )
@@ -107,6 +107,9 @@ func (iface tagsInterface) get(job job) (resources []*tagsData, err error) {
 		filter = append(filter, hotfix)
 	case "asg":
 		return iface.getTaggedAutoscalingGroups(job)
+	case "sqs":
+		hotfix := aws.String("sqs")
+		filter = append(filter, hotfix)
 	default:
 		log.Fatal("Not implemented resources:" + job.Type)
 	}

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ var (
 		"kinesis",
 		"vpn",
 		"asg",
+		"sqs",
 	}
 
 	config = conf{}


### PR DESCRIPTION
This adds support for getting metrics from SQS queues. Note that by
default SQS queues aren't tagged at all, and therefore don't appear in
the resourcegroupstaggingapi. It's therefore necessary to tag them with
something before they'll appear in this exporter.