### PR TITLE
Making docker image use non-root user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.14.2-alpha
+* Changing user in Docker image to be non root to adhere to potential security requirements.
+
 # 0.14.0-alpha
 * **BREAKING** Default command in Dockerfile is changed to yace. This removes the need to add yace as command.
 ```yaml
@@ -278,3 +281,4 @@ jobs:
 * Implement minimum, average, maximum, sum for cloudwatch api
 * Implement way to handle multiple data returned by cloudwatch
 * Update go dependencies
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,13 @@ FROM alpine:latest
 EXPOSE 5000
 ENTRYPOINT ["yace"]
 CMD ["--config.file=/tmp/config.yml"]
-WORKDIR /root/
+RUN addgroup -g 1000 exporter && \
+    adduser -u 1000 -D -G exporter exporter -h /exporter
+
+WORKDIR /exporter/
+
 
 RUN apk --no-cache add ca-certificates
 COPY --from=builder /opt/yace /usr/local/bin/yace
+USER exporter
 

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ The following IAM permissions are required for YACE to work.
 ## Running locally
 
 ```shell
-docker run -d --rm -v $PWD/credentials:/root/.aws/PWD/credentials -v $PWD/config.yml:/tmp/config.yml \
+docker run -d --rm -v $PWD/credentials:/exporter/.aws/PWD/credentials -v $PWD/config.yml:/tmp/config.yml \
 -p 5000:5000 --name yace quay.io/invisionag/yet-another-cloudwatch-exporter:vx.xx.x # release version as tag - Do not forget the version 'v'
 
 ```
@@ -358,3 +358,4 @@ go without losing data. ELB metrics on AWS are written every 5 minutes (300) in 
 
 * [Justin Santa Barbara](https://github.com/justinsb) - For telling me about AWS tags api which simplified a lot - Thanks!
 * [Brian Brazil](https://github.com/brian-brazil) - Who gave a lot of feedback regarding UX and prometheus lib - Thanks!
+


### PR DESCRIPTION
Couldn't push directly to master with tag like the documents explain, so forked and requesting PR into master.

Changes just ensure the docker container is run as a non root user to avoid potential security issues. 