### PR TITLE
FIX| issue#76

### DIFF
--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -388,13 +388,24 @@ func buildDimension(key string, value string) *cloudwatch.Dimension {
 
 func fixServiceName(serviceName *string, dimensions []*cloudwatch.Dimension) string {
 	var suffixName string
+
 	if *serviceName == "alb" {
+		var albSuffix, tgSuffix string
 		for _, dimension := range dimensions {
 			if *dimension.Name == "TargetGroup" {
-				suffixName = "tg"
+				tgSuffix = "tg"
+			}
+			if *dimension.Name == "LoadBalancer" {
+				albSuffix = "alb"
 			}
 		}
+		if albSuffix != "" && tgSuffix != "" {
+			return albSuffix + "_" + tgSuffix
+		} else if albSuffix == "" && tgSuffix != "" {
+			return tgSuffix
+		}
 	}
+
 	if *serviceName == "elb" {
 		for _, dimension := range dimensions {
 			if *dimension.Name == "AvailabilityZone" {


### PR DESCRIPTION

1. This PR will fix https://github.com/ivx/yet-another-cloudwatch-exporter/issues/76
This issue is not there in `v0.14.1`. But v0.14.1 is slow because its calling list metrics API call for each metric.
 And for older version, When we try to discover alb metrics, YACE search for all the alb and TargetGroup resources with the given tag and there is a chance that it will get target group which don't have any parent load balancer
Then we will get the above issue.
```http: panic serving [::1]:51567: descriptors reported by collector have inconsistent label names or help strings for the same fully-qualified name, offender is Desc{fqName: "aws_alb_tg_request_count_sum", help: "Help is not implemented yet.", constLabels: {dimension_TargetGroup="targetgroup/xxxxx",name="xxxx",region="ap-south-1"}, variableLabels: []}``` 

because aws_alb_tg_request_count_sum suppose to have `dimension_LoadBalancer` and `dimension_TargetGroup` lables.

2. We don't need to call listMetrics API call unless there is a  awsDimension specify in config, or there is the dimension with Name in dimension struct and without value(like: availability zone where value can be any Azs). It will improve its performance.


