### PR TITLE
Remove hardcoded StorageType dimension from S3 metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,9 @@ discovery:
           - Average
         period: 86400
         length: 172800
+        additionalDimensions:
+          - name: StorageType
+            value: AllStorageTypes
       - name: BucketSizeBytes
         statistics:
           - Average

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -339,7 +339,6 @@ func detectDimensionsByService(service *string, resourceArn *string, clientCloud
 		dimensions = append(dimensions, buildDimension("ClientId", arnParsed.AccountID))
 	case "s3":
 		dimensions = buildBaseDimension(arnParsed.Resource, "BucketName", "")
-		dimensions = append(dimensions, buildDimension("StorageType", "AllStorageTypes"))
 	case "efs":
 		dimensions = buildBaseDimension(arnParsed.Resource, "FileSystemId", "file-system/")
 	case "ebs":


### PR DESCRIPTION
The "AllStorageTypes" value for the StorageType dimension was only
valid for the NumberOfObjects metric. The BucketSizeBytes metric
required specifying a different StorageType, and request metrics
could not be retrieved at all because they do not have a StorageType
dimension.

Users with "NumberOfObjects" in their configuration will now need to
add "StorageType" under additionalDimensions or awsDimensions.

Fixes #85 