### PR TITLE
Multiple metrics different dimensions

### DIFF
--- a/abstract.go
+++ b/abstract.go
@@ -146,8 +146,8 @@ func scrapeDiscoveryJob(job job, tagsOnMetrics exportedTagsOnMetrics, clientTag 
 		go func() {
 			for j := range job.Metrics {
 				metric := job.Metrics[j]
-				dimensions = addAdditionalDimensions(dimensions, metric.AdditionalDimensions)
-				resp := getMetricsList(dimensions, resource.Service, metric, clientCloudwatch)
+				metricDimensions := addAdditionalDimensions(dimensions, metric.AdditionalDimensions)
+				resp := getMetricsList(metricDimensions, resource.Service, metric, clientCloudwatch)
 				go func() {
 					defer wg.Done()
 					cloudwatchSemaphore <- struct{}{}

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -366,7 +366,8 @@ func detectDimensionsByService(service *string, resourceArn *string, clientCloud
 }
 
 func addAdditionalDimensions(startingDimensions []*cloudwatch.Dimension, additionalDimensions []dimension) (dimensions []*cloudwatch.Dimension) {
-	dimensions = startingDimensions
+	// Copy startingDimensions before appending additionalDimensions, since append(x, ...) can modify x
+	dimensions = append(dimensions, startingDimensions...)
 	for _, dimension := range additionalDimensions {
 		dimensions = append(dimensions, buildDimension(dimension.Name, dimension.Value))
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/aws/aws-sdk-go v1.19.7
+	github.com/fatih/structs v1.1.0
 	github.com/prometheus/client_golang v0.9.2
 	github.com/stretchr/testify v1.3.0 // indirect
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLM
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
+github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=


### PR DESCRIPTION
Avoid appending to a shared `dimensions` variable from inside a loop.

This fixes configuration like this, where the second two metrics would include the `FilterId` dimension that is only declared on the first metric:
```
  - type: s3
    region: us-west-2
    metrics:
    - name: BytesUploaded
      statistics: [Sum]
      period: 60
      length: 600
      delay: 600
      additionalDimensions:
      - name: FilterId
        value: MyFilterId
    - name: NumberOfObjects
      statistics: [Average]
      period: 86400
      length: 172800
      additionalDimensions:
      - name: StorageType
        value: AllStorageTypes
    - name: BucketSizeBytes
      statistics: [Average]
      period: 86400
      length: 172800
      additionalDimensions:
      - name: StorageType
        value: StandardStorage
```