### PR TITLE
Bump aws-sdk-go to v1.25.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ivx/yet-another-cloudwatch-exporter
 go 1.12
 
 require (
-	github.com/aws/aws-sdk-go v1.19.7
+	github.com/aws/aws-sdk-go v1.25.18
 	github.com/prometheus/client_golang v0.9.2
 	github.com/stretchr/testify v1.3.0 // indirect
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 github.com/aws/aws-sdk-go v1.19.7 h1:BEKPfM8DPsXIsz1zL98nSbYqsOUjUM2lm93XLZL0qY8=
 github.com/aws/aws-sdk-go v1.19.7/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.25.18/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=


### PR DESCRIPTION
We are using [IAM Roles for Service Accounts](https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/) to grant IAM access to K8s containers.

Support for this is not present in the existing version of the library, since it was only added later: https://github.com/aws/aws-sdk-go/pull/2667