### PR TITLE
kafka support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ YACE is currently in quick iteration mode. Things will probably break in upcomin
   * sqs - Simple Queue Service
   * vpn - VPN connection
   * asg - Auto Scaling Group
+  * kafka - Managed Apache Kafka
 
 ## Image
 
@@ -229,6 +230,20 @@ discovery:
         period: 600
         length: 600
         addCloudwatchTimestamp: true
+  - type: kafka
+    region: eu-west-1
+    searchTags:
+      - Key: env
+        Value: dev
+    awsDimensions:
+      - Broker ID
+      - Topic
+    metrics:
+      - name: BytesOutPerSec
+        statistics:
+        - Average
+        period: 600
+        length: 600
 static:
   - namespace: AWS/AutoScaling
     name: must_be_set

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -196,6 +196,8 @@ func getNamespace(service *string) *string {
 		ns = "AWS/AutoScaling"
 	case "sqs":
 		ns = "AWS/SQS"
+	case "kafka":
+		ns = "AWS/Kafka"
 	default:
 		log.Fatal("Not implemented namespace for cloudwatch metric: " + *service)
 	}
@@ -357,6 +359,9 @@ func detectDimensionsByService(service *string, resourceArn *string, clientCloud
 		dimensions = buildBaseDimension(arnParsed.Resource, "AutoScalingGroupName", "autoScalingGroupName/")
 	case "sqs":
 		dimensions = buildBaseDimension(arnParsed.Resource, "QueueName", "")
+	case "kafka":
+		cluster := strings.Split(arnParsed.Resource, "/")[1]
+		dimensions = append(dimensions, buildDimension("Cluster Name", cluster))
 	default:
 		log.Fatal("Not implemented cloudwatch metric: " + *service)
 	}

--- a/aws_tags.go
+++ b/aws_tags.go
@@ -118,6 +118,9 @@ func (iface tagsInterface) get(job job) (resources []*tagsData, err error) {
 	case "sqs":
 		hotfix := aws.String("sqs")
 		filter = append(filter, hotfix)
+	case "kafka":
+		hotfix := aws.String("kafka:cluster")
+		filter = append(filter, hotfix)
 	default:
 		log.Fatal("Not implemented resources:" + job.Type)
 	}

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ var (
 		"vpn",
 		"asg",
 		"sqs",
+		"kafka",
 	}
 
 	config = conf{}

--- a/prometheus.go
+++ b/prometheus.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -74,13 +75,26 @@ func removeDuplicatedMetrics(metrics []*PrometheusMetric) []*PrometheusMetric {
 	keys := make(map[string]bool)
 	filteredMetrics := []*PrometheusMetric{}
 	for _, metric := range metrics {
-		check := *metric.name + metric.labels["name"]
+		check := *metric.name + combineLabels(metric.labels)
 		if _, value := keys[check]; !value {
 			keys[check] = true
 			filteredMetrics = append(filteredMetrics, metric)
 		}
 	}
 	return filteredMetrics
+}
+
+func combineLabels(labels map[string]string) string {
+	var combinedLabels string
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		combinedLabels += promString(k) + promString(labels[k])
+	}
+	return combinedLabels
 }
 
 func promString(text string) string {


### PR DESCRIPTION
* Adds AWS/Kafka support 

We also changed removeDuplicatedMetrics little bit , as it only checks "name" label , for kafka broker metrics , it was removing some valid metrics. 

created combileLabels function , in order to combine all labels for given metric. What do you think?

```
func combineLabels(labels map[string]string) string {
	var combinedLabels string
	keys := make([]string, 0, len(labels))
	for k := range labels {
		keys = append(keys, k)
	}
	sort.Strings(keys)
	for _, k := range keys {
		combinedLabels += promString(k) + promString(labels[k])
	}
	return combinedLabels
}
```