### PR TITLE
add some validations

### DIFF
--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -322,10 +322,10 @@ func detectDimensionsByService(service *string, resourceArn *string, clientCloud
 	case "elb":
 		dimensions = buildBaseDimension(arnParsed.Resource, "LoadBalancerName", "loadbalancer/")
 	case "ecs-svc":
-		cluster := strings.Split(arnParsed.Resource, "/")[1]
-		service := strings.Split(arnParsed.Resource, "/")[2]
-		dimensions = append(dimensions, buildDimension("ClusterName", cluster))
-		dimensions = append(dimensions, buildDimension("ServiceName", service))
+		parsedResource := strings.Split(arnParsed.Resource, "/")
+		if parsedResource[0] == "service" {
+			dimensions = append(dimensions, buildDimension("ClusterName", parsedResource[1]), buildDimension("ServiceName", parsedResource[2]))
+		}
 	case "alb":
 		dimensions = queryAvailableDimensions(arnParsed.Resource, getNamespace(service), clientCloudwatch)
 	case "nlb":

--- a/config.go
+++ b/config.go
@@ -78,6 +78,10 @@ func (c *conf) load(file *string) error {
 			if metric.Length < 300 {
 				log.Output(2, "WATCH OUT! - Metric length of less than 5 minutes configured which is default for most cloudwatch metrics e.g. ELBs")
 			}
+
+			if metric.Period < 1 {
+				return fmt.Errorf("Period value should be a positive integer")
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Adding some validations:
- If period is not supplied, AWS complains about the default 0 value so forcing some default non-zero values.
- If the ECS resource returned through the filter is a cluster, the assumed dimensions are not there causing panic in the code. Maybe the filter part is a better place for this but this will make sure those are no-ops for the code.