### PR TITLE
code readability cleanup on switch cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ spec:
           name: yace
 ```
 
-## Troubleshooting / Debuging
+## Troubleshooting / Debugging
 
 ### Help my metrics are intermittent
 

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -443,6 +443,13 @@ func migrateCloudwatchToPrometheus(cwd []*cloudwatchData) []*PrometheusMetric {
 			var timestamp time.Time
 			for _, datapoint := range datapoints {
 				switch {
+				case statistic == "Average":
+					if datapoint.Average != nil {
+						if datapoint.Timestamp.After(timestamp) {
+							timestamp = *datapoint.Timestamp
+						}
+						averageDataPoints = append(averageDataPoints, datapoint.Average)
+					}
 				case statistic == "Maximum":
 					if datapoint.Maximum != nil {
 						exportedDatapoint = datapoint.Maximum
@@ -460,13 +467,6 @@ func migrateCloudwatchToPrometheus(cwd []*cloudwatchData) []*PrometheusMetric {
 						exportedDatapoint = datapoint.Sum
 						timestamp = *datapoint.Timestamp
 						break
-					}
-				case statistic == "Average":
-					if datapoint.Average != nil {
-						if datapoint.Timestamp.After(timestamp) {
-							timestamp = *datapoint.Timestamp
-						}
-						averageDataPoints = append(averageDataPoints, datapoint.Average)
 					}
 				case percentile.MatchString(statistic):
 					if data, ok := datapoint.ExtendedStatistics[statistic]; ok {

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -317,46 +317,46 @@ func detectDimensionsByService(service *string, resourceArn *string, clientCloud
 	}
 
 	switch *service {
+	case "alb":
+		dimensions = queryAvailableDimensions(arnParsed.Resource, getNamespace(service), clientCloudwatch)
+	case "asg":
+		dimensions = buildBaseDimension(arnParsed.Resource, "AutoScalingGroupName", "autoScalingGroupName/")
+	case "dynamodb":
+		dimensions = buildBaseDimension(arnParsed.Resource, "TableName", "table/")
+	case "ebs":
+		dimensions = buildBaseDimension(arnParsed.Resource, "VolumeId", "volume/")
+	case "ec":
+		dimensions = buildBaseDimension(arnParsed.Resource, "CacheClusterId", "cluster:")
 	case "ec2":
 		dimensions = buildBaseDimension(arnParsed.Resource, "InstanceId", "instance/")
-	case "elb":
-		dimensions = buildBaseDimension(arnParsed.Resource, "LoadBalancerName", "loadbalancer/")
 	case "ecs-svc":
 		cluster := strings.Split(arnParsed.Resource, "/")[1]
 		service := strings.Split(arnParsed.Resource, "/")[2]
 		dimensions = append(dimensions, buildDimension("ClusterName", cluster))
 		dimensions = append(dimensions, buildDimension("ServiceName", service))
-	case "alb":
-		dimensions = queryAvailableDimensions(arnParsed.Resource, getNamespace(service), clientCloudwatch)
+	case "efs":
+		dimensions = buildBaseDimension(arnParsed.Resource, "FileSystemId", "file-system/")
+	case "elb":
+		dimensions = buildBaseDimension(arnParsed.Resource, "LoadBalancerName", "loadbalancer/")
+	case "emr":
+		dimensions = buildBaseDimension(arnParsed.Resource, "JobFlowId", "cluster/")
+	case "es":
+		dimensions = buildBaseDimension(arnParsed.Resource, "DomainName", "domain/")
+		dimensions = append(dimensions, buildDimension("ClientId", arnParsed.AccountID))
+	case "kinesis":
+		dimensions = buildBaseDimension(arnParsed.Resource, "StreamName", "stream/")
+	case "lambda":
+		dimensions = buildBaseDimension(arnParsed.Resource, "FunctionName", "function:")
 	case "nlb":
 		dimensions = buildBaseDimension(arnParsed.Resource, "LoadBalancer", "loadbalancer/")
 	case "rds":
 		dimensions = buildBaseDimension(arnParsed.Resource, "DBInstanceIdentifier", "db:")
-	case "ec":
-		dimensions = buildBaseDimension(arnParsed.Resource, "CacheClusterId", "cluster:")
-	case "es":
-		dimensions = buildBaseDimension(arnParsed.Resource, "DomainName", "domain/")
-		dimensions = append(dimensions, buildDimension("ClientId", arnParsed.AccountID))
 	case "s3":
 		dimensions = buildBaseDimension(arnParsed.Resource, "BucketName", "")
-	case "efs":
-		dimensions = buildBaseDimension(arnParsed.Resource, "FileSystemId", "file-system/")
-	case "ebs":
-		dimensions = buildBaseDimension(arnParsed.Resource, "VolumeId", "volume/")
-	case "vpn":
-		dimensions = buildBaseDimension(arnParsed.Resource, "VpnId", "vpn-connection/")
-	case "lambda":
-		dimensions = buildBaseDimension(arnParsed.Resource, "FunctionName", "function:")
-	case "kinesis":
-		dimensions = buildBaseDimension(arnParsed.Resource, "StreamName", "stream/")
-	case "dynamodb":
-		dimensions = buildBaseDimension(arnParsed.Resource, "TableName", "table/")
-	case "emr":
-		dimensions = buildBaseDimension(arnParsed.Resource, "JobFlowId", "cluster/")
-	case "asg":
-		dimensions = buildBaseDimension(arnParsed.Resource, "AutoScalingGroupName", "autoScalingGroupName/")
 	case "sqs":
 		dimensions = buildBaseDimension(arnParsed.Resource, "QueueName", "")
+	case "vpn":
+		dimensions = buildBaseDimension(arnParsed.Resource, "VpnId", "vpn-connection/")
 	default:
 		log.Fatal("Not implemented cloudwatch metric: " + *service)
 	}

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -160,42 +160,42 @@ func (iface cloudwatchInterface) get(filter *cloudwatch.GetMetricStatisticsInput
 func getNamespace(service *string) *string {
 	var ns string
 	switch *service {
-	case "ec2":
-		ns = "AWS/EC2"
-	case "elb":
-		ns = "AWS/ELB"
 	case "alb":
 		ns = "AWS/ApplicationELB"
-	case "rds":
-		ns = "AWS/RDS"
-	case "ec":
-		ns = "AWS/ElastiCache"
-	case "es":
-		ns = "AWS/ES"
-	case "ecs-svc":
-		ns = "AWS/ECS"
-	case "nlb":
-		ns = "AWS/NetworkELB"
-	case "s3":
-		ns = "AWS/S3"
-	case "efs":
-		ns = "AWS/EFS"
-	case "ebs":
-		ns = "AWS/EBS"
-	case "vpn":
-		ns = "AWS/VPN"
-	case "lambda":
-		ns = "AWS/Lambda"
-	case "kinesis":
-		ns = "AWS/Kinesis"
-	case "dynamodb":
-		ns = "AWS/DynamoDB"
-	case "emr":
-		ns = "AWS/ElasticMapReduce"
 	case "asg":
 		ns = "AWS/AutoScaling"
+	case "dynamodb":
+		ns = "AWS/DynamoDB"
+	case "ebs":
+		ns = "AWS/EBS"
+	case "ec":
+		ns = "AWS/ElastiCache"
+	case "ec2":
+		ns = "AWS/EC2"
+	case "ecs-svc":
+		ns = "AWS/ECS"
+	case "efs":
+		ns = "AWS/EFS"
+	case "elb":
+		ns = "AWS/ELB"
+	case "emr":
+		ns = "AWS/ElasticMapReduce"
+	case "es":
+		ns = "AWS/ES"
+	case "kinesis":
+		ns = "AWS/Kinesis"
+	case "lambda":
+		ns = "AWS/Lambda"
+	case "nlb":
+		ns = "AWS/NetworkELB"
+	case "rds":
+		ns = "AWS/RDS"
+	case "s3":
+		ns = "AWS/S3"
 	case "sqs":
 		ns = "AWS/SQS"
+	case "vpn":
+		ns = "AWS/VPN"
 	default:
 		log.Fatal("Not implemented namespace for cloudwatch metric: " + *service)
 	}

--- a/aws_tags.go
+++ b/aws_tags.go
@@ -61,63 +61,44 @@ func (iface tagsInterface) get(job job) (resources []*tagsData, err error) {
 	var filter []*string
 
 	switch job.Type {
-	case "ec2":
-		hotfix := aws.String("ec2:instance")
-		filter = append(filter, hotfix)
-	case "ecs-svc":
-		hotfix := aws.String("ecs:cluster")
-		svc := aws.String("ecs:service")
-		filter = append(filter, hotfix)
-		filter = append(filter, svc)
-	case "elb":
-		hotfix := aws.String("elasticloadbalancing:loadbalancer")
-		filter = append(filter, hotfix)
 	case "alb":
-		alb := aws.String("elasticloadbalancing:loadbalancer")
-		tg := aws.String("elasticloadbalancing:targetgroup")
-		filter = append(filter, alb)
-		filter = append(filter, tg)
-	case "nlb":
-		alb := aws.String("elasticloadbalancing:loadbalancer/net")
-		filter = append(filter, alb)
-	case "vpn":
-		connection := aws.String("ec2:vpn-connection")
-		filter = append(filter, connection)
-	case "rds":
-		hotfix := aws.String("rds:db")
-		filter = append(filter, hotfix)
-	case "es":
-		hotfix := aws.String("es:domain")
-		filter = append(filter, hotfix)
-	case "ec":
-		hotfix := aws.String("elasticache:cluster")
-		filter = append(filter, hotfix)
-	case "s3":
-		hotfix := aws.String("s3")
-		filter = append(filter, hotfix)
-	case "efs":
-		hotfix := aws.String("elasticfilesystem:file-system")
-		filter = append(filter, hotfix)
-	case "ebs":
-		hotfix := aws.String("ec2:volume")
-		filter = append(filter, hotfix)
-	case "lambda":
-		hotfix := aws.String("lambda:function")
-		filter = append(filter, hotfix)
-	case "kinesis":
-		hotfix := aws.String("kinesis:stream")
-		filter = append(filter, hotfix)
-	case "dynamodb":
-		hotfix := aws.String("dynamodb:table")
-		filter = append(filter, hotfix)
-	case "emr":
-		hotfix := aws.String("elasticmapreduce:cluster")
-		filter = append(filter, hotfix)
+		filter = append(filter, aws.String("elasticloadbalancing:loadbalancer"))
+		filter = append(filter, aws.String("elasticloadbalancing:targetgroup"))
 	case "asg":
 		return iface.getTaggedAutoscalingGroups(job)
+	case "dynamodb":
+		filter = append(filter, aws.String("dynamodb:table"))
+	case "ebs":
+		filter = append(filter, aws.String("ec2:volume"))
+	case "ec":
+		filter = append(filter, aws.String("elasticache:cluster"))
+	case "ec2":
+		filter = append(filter, aws.String("ec2:instance"))
+	case "ecs-svc":
+		filter = append(filter, aws.String("ecs:cluster"))
+		filter = append(filter, aws.String("ecs:service"))
+	case "efs":
+		filter = append(filter, aws.String("elasticfilesystem:file-system"))
+	case "elb":
+		filter = append(filter, aws.String("elasticloadbalancing:loadbalancer"))
+	case "emr":
+		filter = append(filter, aws.String("elasticmapreduce:cluster"))
+	case "es":
+		filter = append(filter, aws.String("es:domain"))
+	case "kinesis":
+		filter = append(filter, aws.String("kinesis:stream"))
+	case "lambda":
+		filter = append(filter, aws.String("lambda:function"))
+	case "nlb":
+		filter = append(filter, aws.String("elasticloadbalancing:loadbalancer/net"))
+	case "rds":
+		filter = append(filter, aws.String("rds:db"))
+	case "s3":
+		filter = append(filter, aws.String("s3"))
 	case "sqs":
-		hotfix := aws.String("sqs")
-		filter = append(filter, hotfix)
+		filter = append(filter, aws.String("sqs"))
+	case "vpn":
+		filter = append(filter, aws.String("ec2:vpn-connection"))
 	default:
 		log.Fatal("Not implemented resources:" + job.Type)
 	}

--- a/main.go
+++ b/main.go
@@ -23,23 +23,23 @@ var (
 
 	supportedServices = []string{
 		"alb",
+		"asg",
 		"dynamodb",
 		"ebs",
 		"ec",
-		"ecs-svc",
 		"ec2",
+		"ecs-svc",
 		"efs",
 		"elb",
 		"emr",
 		"es",
+		"kinesis",
 		"lambda",
 		"nlb",
 		"rds",
 		"s3",
-		"kinesis",
-		"vpn",
-		"asg",
 		"sqs",
+		"vpn",
 	}
 
 	config = conf{}


### PR DESCRIPTION
Some obvious low hanging fruit to clean up the readability of the code.

- Orders the switch cases to be alphabetical
- Remove the `hotfix` variables and merge them down to one line instead.