### PR TITLE
Added support for ECS/ContainerInsights (Fargate metrics)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ YACE is currently in quick iteration mode. Things will probably break in upcomin
   * ec - ElastiCache
   * ec2 - Elastic Compute Cloud
   * ecs-svc - Elastic Container Service (Service Metrics)
+  * ecs-containerinsights - ECS/ContainerInsights (Fargate metrics)
   * efs - Elastic File System
   * elb - Elastic Load Balancer
   * emr - Elastic MapReduce

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -175,6 +175,8 @@ func getNamespace(service *string) *string {
 		ns = "AWS/EC2"
 	case "ecs-svc":
 		ns = "AWS/ECS"
+	case "ecs-containerinsights":
+		ns = "ECS/ContainerInsights"
 	case "efs":
 		ns = "AWS/EFS"
 	case "elb":
@@ -332,7 +334,7 @@ func detectDimensionsByService(service *string, resourceArn *string, clientCloud
 		dimensions = buildBaseDimension(arnParsed.Resource, "CacheClusterId", "cluster:")
 	case "ec2":
 		dimensions = buildBaseDimension(arnParsed.Resource, "InstanceId", "instance/")
-	case "ecs-svc":
+	case "ecs-svc", "ecs-containerinsights":
 		parsedResource := strings.Split(arnParsed.Resource, "/")
 		if parsedResource[0] == "service" {
 			dimensions = append(dimensions, buildDimension("ClusterName", parsedResource[1]), buildDimension("ServiceName", parsedResource[2]))

--- a/aws_tags.go
+++ b/aws_tags.go
@@ -73,7 +73,7 @@ func (iface tagsInterface) get(job job) (resources []*tagsData, err error) {
 		filter = append(filter, aws.String("elasticache:cluster"))
 	case "ec2":
 		filter = append(filter, aws.String("ec2:instance"))
-	case "ecs-svc":
+	case "ecs-svc", "ecs-containerinsights":
 		filter = append(filter, aws.String("ecs:cluster"))
 		filter = append(filter, aws.String("ecs:service"))
 	case "efs":

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ var (
 		"ec",
 		"ec2",
 		"ecs-svc",
+		"ecs-containerinsights",
 		"efs",
 		"elb",
 		"emr",


### PR DESCRIPTION
Support for the ECS/ContainerInsights namespace that provides metrics from AWS Fargate.

- New service: ecs-containerinsights

Configuration example: 
```
discovery:
  jobs:
  - region: us-east-1
    type: ecs-containerinsights
    awsDimensions: 
      - ClusterName
    metrics: 
      - name: ContainerInstanceCount
        statistics:
        - Average
        period: 60
        length: 300
```