### PR TITLE
Resources added to auto discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,14 @@ YACE is currently in quick iteration mode. Things will probably break in upcomin
   * emr - Elastic MapReduce
   * es - ElasticSearch
   * kinesis - Kinesis Data Stream
+  * ngw - Nat Gateway
   * lambda - Lambda Functions
   * nlb - Network Load Balancer
   * rds - Relational Database Service
+  * r53r - Route53 Resolver
   * s3 - Object Storage
   * sqs - Simple Queue Service
+  * tgw - Transit Gateway
   * vpn - VPN connection
   * asg - Auto Scaling Group
   * kafka - Managed Apache Kafka

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -187,16 +187,22 @@ func getNamespace(service *string) *string {
 		ns = "AWS/Kafka"
 	case "kinesis":
 		ns = "AWS/Kinesis"
+	case "ngw":
+		ns = "AWS/NATGateway"
 	case "lambda":
 		ns = "AWS/Lambda"
 	case "nlb":
 		ns = "AWS/NetworkELB"
 	case "rds":
 		ns = "AWS/RDS"
+	case "r53r":
+		ns = "AWS/Route53Resolver"
 	case "s3":
 		ns = "AWS/S3"
 	case "sqs":
 		ns = "AWS/SQS"
+	case "tgw":
+		ns = "AWS/TransitGateway"
 	case "vpn":
 		ns = "AWS/VPN"
 	default:
@@ -350,14 +356,20 @@ func detectDimensionsByService(service *string, resourceArn *string, clientCloud
 		dimensions = buildBaseDimension(arnParsed.Resource, "StreamName", "stream/")
 	case "lambda":
 		dimensions = buildBaseDimension(arnParsed.Resource, "FunctionName", "function:")
+	case "ngw":
+		dimensions = buildBaseDimension(arnParsed.Resource, "NatGatewayId", "natgateway/")
 	case "nlb":
 		dimensions = buildBaseDimension(arnParsed.Resource, "LoadBalancer", "loadbalancer/")
 	case "rds":
 		dimensions = buildBaseDimension(arnParsed.Resource, "DBInstanceIdentifier", "db:")
+	case "r53r":
+		dimensions = buildBaseDimension(arnParsed.Resource, "EndpointId", "resolver-endpoint/")
 	case "s3":
 		dimensions = buildBaseDimension(arnParsed.Resource, "BucketName", "")
 	case "sqs":
 		dimensions = buildBaseDimension(arnParsed.Resource, "QueueName", "")
+	case "tgw":
+		dimensions = buildBaseDimension(arnParsed.Resource, "TransitGateway", "transit-gateway/")
 	case "vpn":
 		dimensions = buildBaseDimension(arnParsed.Resource, "VpnId", "vpn-connection/")
 	case "kafka":

--- a/aws_tags.go
+++ b/aws_tags.go
@@ -88,14 +88,20 @@ func (iface tagsInterface) get(job job) (resources []*tagsData, err error) {
 		filter = append(filter, aws.String("kinesis:stream"))
 	case "lambda":
 		filter = append(filter, aws.String("lambda:function"))
+	case "ngw":
+		filter = append(filter, aws.String("ec2:natgateway"))
 	case "nlb":
 		filter = append(filter, aws.String("elasticloadbalancing:loadbalancer/net"))
 	case "rds":
 		filter = append(filter, aws.String("rds:db"))
+	case "r53r":
+		filter = append(filter, aws.String("route53resolver"))
 	case "s3":
 		filter = append(filter, aws.String("s3"))
 	case "sqs":
 		filter = append(filter, aws.String("sqs"))
+	case "tgw":
+		filter = append(filter, aws.String("ec2:transit-gateway"))
 	case "vpn":
 		filter = append(filter, aws.String("ec2:vpn-connection"))
 	case "kafka":

--- a/main.go
+++ b/main.go
@@ -36,10 +36,13 @@ var (
 		"kafka",
 		"kinesis",
 		"lambda",
+		"ngw",
 		"nlb",
 		"rds",
+		"r53r",
 		"s3",
 		"sqs",
+		"tgw",
 		"vpn",
 	}
 


### PR DESCRIPTION
The following resources are now supported by auto-discovery via tags:

* Nat Gateway (by NatGatewayId)
* Transit Gateway (by TransitGateway)
* Route53 Resolver (by EndpointId)