### PR TITLE
Refactor debug logging

### DIFF
--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -83,20 +83,18 @@ func createGetMetricStatisticsInput(dimensions []*cloudwatch.Dimension, namespac
 		ExtendedStatistics: extendedStatistics,
 	}
 
-	if *debug {
-		if len(statistics) != 0 {
-			log.Println("CLI helper - " +
-				"aws cloudwatch get-metric-statistics" +
-				" --metric-name " + metric.Name +
-				" --dimensions " + dimensionsToCliString(dimensions) +
-				" --namespace " + *namespace +
-				" --statistics " + *statistics[0] +
-				" --period " + strconv.FormatInt(period, 10) +
-				" --start-time " + startTime.Format(time.RFC3339) +
-				" --end-time " + endTime.Format(time.RFC3339))
-		}
-		log.Println(*output)
+	if len(statistics) != 0 {
+		log.Debug("CLI helper - " +
+			"aws cloudwatch get-metric-statistics" +
+			" --metric-name " + metric.Name +
+			" --dimensions " + dimensionsToCliString(dimensions) +
+			" --namespace " + *namespace +
+			" --statistics " + *statistics[0] +
+			" --period " + strconv.FormatInt(period, 10) +
+			" --start-time " + startTime.Format(time.RFC3339) +
+			" --end-time " + endTime.Format(time.RFC3339))
 	}
+	log.Debug(*output)
 	return output
 }
 
@@ -139,15 +137,11 @@ func dimensionsToCliString(dimensions []*cloudwatch.Dimension) (output string) {
 func (iface cloudwatchInterface) get(filter *cloudwatch.GetMetricStatisticsInput) []*cloudwatch.Datapoint {
 	c := iface.client
 
-	if *debug {
-		log.Println(filter)
-	}
+	log.Debug(filter)
 
 	resp, err := c.GetMetricStatistics(filter)
 
-	if *debug {
-		log.Println(resp)
-	}
+	log.Debug(resp)
 
 	cloudwatchAPICounter.Inc()
 

--- a/main.go
+++ b/main.go
@@ -92,9 +92,13 @@ func main() {
 		os.Exit(0)
 	}
 
+	if *debug {
+		log.SetLevel(log.DebugLevel)
+	}
+
 	log.Println("Parse config..")
 	if err := config.load(configFile); err != nil {
-		log.Fatal("Couldn't read ", *configFile, ":", err)
+		log.Fatal("Couldn't read ", *configFile, ": ", err)
 	}
 
 	cloudwatchSemaphore = make(chan struct{}, *cloudwatchConcurrency)


### PR DESCRIPTION
Hi @thomaspeitz, a few I think useful additions to logging logic if you wish to implement!

Debug logic now only happens once, and utilises the `log.Debug()`
function, rather than log.Print() with multiple checks on the existance
of *debug.

"Standard" logging introduced, human-readable timestamped coloured output for reading in TTY sessions.

The following flags added for logging:
`-logfile` - write logs to directory, defaults to stdout
`-logformat` - format of log standard/json, defaults to json

ps: ignore commit 371657b within this PR, this is because I based this branch off my other work, but should be good to go standalone! 👍 