### PR TITLE
Fix ClusterName dimension in ECS/Containerinsights

### DIFF
--- a/abstract.go
+++ b/abstract.go
@@ -160,25 +160,27 @@ func scrapeDiscoveryJobUsingMetricData(job job, tagsOnMetrics exportedTagsOnMetr
 				dimensions = addAdditionalDimensions(dimensions, metric.AdditionalDimensions)
 				resp := getMetricsList(dimensions, resource.Service, metric, clientCloudwatch)
 				defer wg.Done()
-				for _, fetchedMetrics := range resp.Metrics {
-					for _, stats := range metric.Statistics {
-						id := fmt.Sprintf("id_%d", rand.Int())
-						period := int64(metric.Period)
-						mux.Lock()
-						getMetricDatas = append(getMetricDatas, cloudwatchData{
-							ID:                     resource.ID,
-							MetricID:               &id,
-							Metric:                 &metric.Name,
-							Service:                resource.Service,
-							Statistics:             []string{stats},
-							NilToZero:              &metric.NilToZero,
-							AddCloudwatchTimestamp: &metric.AddCloudwatchTimestamp,
-							Tags:                   metricTags,
-							Dimensions:             fetchedMetrics.Dimensions,
-							Region:                 &job.Region,
-							Period:                 &period,
-						})
-						mux.Unlock()
+				if resp != nil {
+					for _, fetchedMetrics := range resp.Metrics {
+						for _, stats := range metric.Statistics {
+							id := fmt.Sprintf("id_%d", rand.Int())
+							period := int64(metric.Period)
+							mux.Lock()
+							getMetricDatas = append(getMetricDatas, cloudwatchData{
+								ID:                     resource.ID,
+								MetricID:               &id,
+								Metric:                 &metric.Name,
+								Service:                resource.Service,
+								Statistics:             []string{stats},
+								NilToZero:              &metric.NilToZero,
+								AddCloudwatchTimestamp: &metric.AddCloudwatchTimestamp,
+								Tags:                   metricTags,
+								Dimensions:             fetchedMetrics.Dimensions,
+								Region:                 &job.Region,
+								Period:                 &period,
+							})
+							mux.Unlock()
+						}
 					}
 				}
 			}

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -415,6 +415,9 @@ func detectDimensionsByService(service *string, resourceArn *string, clientCloud
 		if parsedResource[0] == "service" {
 			dimensions = append(dimensions, buildDimension("ClusterName", parsedResource[1]), buildDimension("ServiceName", parsedResource[2]))
 		}
+		if parsedResource[0] == "cluster" {
+			dimensions = append(dimensions, buildDimension("ClusterName", parsedResource[1]))
+		}
 	case "efs":
 		dimensions = buildBaseDimension(arnParsed.Resource, "FileSystemId", "file-system/")
 	case "elb":


### PR DESCRIPTION
Fix a bug causing the incorrect adquisition of the dimension "ClusterName" in Fargate metrics. 

With this fix, the ClusterName dimension is automatically detected. The configuration file for Fargate metrics would be this way: 

```
discovery:
  jobs:
  - region: us-east-1
    type: ecs-containerinsights
    enableMetricData: true
    metrics: 
      - name: ContainerInstanceCount
        statistics:
        - Average
        period: 60
        length: 300

  - region: us-east-1
    type: ecs-containerinsights
    enableMetricData: true
    awsDimensions: 
      - ServiceName
    metrics: 
      - name: CpuReserved
        statistics: 
        - Average
        period: 60
        length: 300
        nilToZero: true
```