### PR TITLE
Prevents exporter to exit on throtlling or unexpected answers from CW

### DIFF
--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -200,7 +200,8 @@ func (iface cloudwatchInterface) get(filter *cloudwatch.GetMetricStatisticsInput
 	cloudwatchGetMetricStatisticsAPICounter.Inc()
 
 	if err != nil {
-		log.Fatal(err)
+		log.Warning(err)
+		return nil
 	}
 
 	return resp.Datapoints
@@ -223,7 +224,8 @@ func (iface cloudwatchInterface) getMetricData(filter *cloudwatch.GetMetricDataI
 	cloudwatchGetMetricDataAPICounter.Inc()
 
 	if err != nil {
-		panic(err)
+		log.Warning(err)
+		return nil
 	}
 	return resp
 }
@@ -324,7 +326,8 @@ func getResourceValue(resourceName string, dimensions []*cloudwatch.Dimension, n
 	err := req.Send()
 
 	if err != nil {
-		log.Fatal(err)
+		log.Warning(err)
+		return (nil)
 	}
 
 	cloudwatchAPICounter.Inc()
@@ -359,7 +362,7 @@ func getMetricsList(dimensions []*cloudwatch.Dimension, serviceName *string, met
 			})
 		cloudwatchAPICounter.Inc()
 		if err != nil {
-			log.Fatal(err)
+			log.Warning(err)
 		}
 		resp = filterMetricsBasedOnDimensions(dimensions, &res)
 	} else {
@@ -394,7 +397,8 @@ func detectDimensionsByService(service *string, resourceArn *string, clientCloud
 	arnParsed, err := arn.Parse(*resourceArn)
 
 	if err != nil {
-		log.Fatal(err)
+		log.Warning(err)
+		return (dimensions)
 	}
 
 	switch *service {

--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ func metricsHandler(w http.ResponseWriter, req *http.Request) {
 	registry.MustRegister(NewPrometheusCollector(metrics))
 	for _, counter := range []prometheus.Counter{cloudwatchAPICounter, cloudwatchGetMetricDataAPICounter, cloudwatchGetMetricStatisticsAPICounter, resourceGroupTaggingAPICounter, autoScalingAPICounter} {
 		if err := registry.Register(counter); err != nil {
-			log.Fatal("Could not publish cloudwatch api metric")
+			log.Warning("Could not publish cloudwatch api metric")
 		}
 	}
 	handler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{


### PR DESCRIPTION
- Controls the reception of errors from Cloudwatch preventing the exporter to exit on scenarios of throtlling or unexpected answers.