### PR TITLE
Decouple scraping and serving metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ searchTags:
 | Key                    | Description |
 | ---------------------- | -------------------------------------------------------------------------------- |
 | name                   | CloudWatch metric name                                                           |
-| statistics             | List of statictic types, e.g. "Mininum", "Maximum", etc.                         |
+| statistics             | List of statistic types, e.g. "Minimum", "Maximum", etc.                         |
 | period                 | Statistic period in seconds                                                      |
 | length                 | How far back to request data for in seconds(for static jobs)                     |
 | delay                  | If set it will request metrics up until `current_time - delay`(for static jobs)  |
@@ -367,13 +367,27 @@ spec:
         configMap:
           name: yace
 ```
+## Options
+### Requests concurrency
+The flags 'cloudwatch-concurrency' and 'tag-concurrency' define the number of concurrent request to cloudwatch metrics and tags. Their default value is 5. 
+
+Setting a higher value makes faster scraping times but can incur in throttling and the blocking of the API. 
+
+### Decoupled scraping
+The flag 'decoupled-scraping' makes the exporter to scrape Cloudwatch metrics in background in fixed intervals, in stead of each time that the '/metrics' endpoint is fetched. This protects from the abuse of API requests that can cause extra billing in AWS account. This flag is activated by default.
+
+If the flag 'decoupled-scraping' is activated, the flag 'scraping-interval' defines the seconds between scrapes. Its default value is 300.
 
 ## Troubleshooting / Debugging
 
 ### Help my metrics are intermittent
 
-* Please try out a bigger length e.g. for elb try out a length of 600 and a period of 600. Then test how low you can
+* Please, try out a bigger length e.g. for elb try out a length of 600 and a period of 600. Then test how low you can
 go without losing data. ELB metrics on AWS are written every 5 minutes (300) in default.
+
+### My metrics only show new values after 5 minutes
+
+* Please, try to set a lower value for the 'scraping-interval' flag or set the 'decoupled-scraping' to false.
 
 ## Contribute
 

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -16,10 +17,12 @@ var version = "custom-build"
 var (
 	addr                  = flag.String("listen-address", ":5000", "The address to listen on.")
 	configFile            = flag.String("config.file", "config.yml", "Path to configuration file.")
-	debug                 = flag.Bool("debug", false, "Add verbose logging")
+	debug                 = flag.Bool("debug", false, "Add verbose logging.")
 	showVersion           = flag.Bool("v", false, "prints current yace version.")
-	cloudwatchConcurrency = flag.Int("cloudwatch-concurrency", 5, "Maximum number of concurrent requests to CloudWatch API")
-	tagConcurrency        = flag.Int("tag-concurrency", 5, "Maximum number of concurrent requests to Resource Tagging API")
+	cloudwatchConcurrency = flag.Int("cloudwatch-concurrency", 5, "Maximum number of concurrent requests to CloudWatch API.")
+	tagConcurrency        = flag.Int("tag-concurrency", 5, "Maximum number of concurrent requests to Resource Tagging API.")
+	scrapingInterval      = flag.Int("scraping-interval", 300, "Seconds to wait between scraping the AWS metrics if decoupled scraping.")
+	decoupledScraping     = flag.Bool("decoupled-scraping", true, "Decouples scraping and serving of metrics.")
 
 	supportedServices = []string{
 		"alb",
@@ -60,7 +63,7 @@ func init() {
 
 }
 
-func metricsHandler(w http.ResponseWriter, req *http.Request) {
+func updateMetrics(registry *prometheus.Registry) {
 	tagsData, cloudwatchData := scrapeAwsData(config)
 
 	var metrics []*PrometheusMetric
@@ -68,18 +71,12 @@ func metricsHandler(w http.ResponseWriter, req *http.Request) {
 	metrics = append(metrics, migrateCloudwatchToPrometheus(cloudwatchData)...)
 	metrics = append(metrics, migrateTagsToPrometheus(tagsData)...)
 
-	registry := prometheus.NewRegistry()
 	registry.MustRegister(NewPrometheusCollector(metrics))
 	for _, counter := range []prometheus.Counter{cloudwatchAPICounter, cloudwatchGetMetricDataAPICounter, cloudwatchGetMetricStatisticsAPICounter, resourceGroupTaggingAPICounter, autoScalingAPICounter} {
 		if err := registry.Register(counter); err != nil {
 			log.Fatal("Could not publish cloudwatch api metric")
 		}
 	}
-	handler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{
-		DisableCompression: false,
-	})
-
-	handler.ServeHTTP(w, req)
 }
 
 func main() {
@@ -98,7 +95,21 @@ func main() {
 	cloudwatchSemaphore = make(chan struct{}, *cloudwatchConcurrency)
 	tagSemaphore = make(chan struct{}, *tagConcurrency)
 
+	registry := prometheus.NewRegistry()
+
 	log.Println("Startup completed")
+
+	if *decoupledScraping {
+		go func() {
+			for {
+				newRegistry := prometheus.NewRegistry()
+				updateMetrics(newRegistry)
+				log.Debug("Metrics scraped.")
+				registry = newRegistry
+				time.Sleep(time.Duration(*scrapingInterval) * time.Second)
+			}
+		}()
+	}
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`<html>
@@ -110,6 +121,18 @@ func main() {
 		</html>`))
 	})
 
-	http.HandleFunc("/metrics", metricsHandler)
+	http.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
+		if !(*decoupledScraping) {
+			newRegistry := prometheus.NewRegistry()
+			updateMetrics(newRegistry)
+			log.Debug("Metrics scraped.")
+			registry = newRegistry
+		}
+		handler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{
+			DisableCompression: false,
+		})
+		handler.ServeHTTP(w, r)
+	})
+
 	log.Fatal(http.ListenAndServe(*addr, nil))
 }


### PR DESCRIPTION
This pull request separate the scraping of metrics from the serving of metrics as commented in #130 .

The objective of decoupling is not to generate excess of Cloudwatch API requests in scenarios of incorrect configuration, attack or concurrent scraping of the exporter. This can cause the blocking of the API for throttling and billing costs for the use of the API.

The decoupled scraping can be activated/deactivated by the flag 'decoupled-scraping' (default value: true). Also, the scraping interval is configurable by the flag 'scraping-interval' (default value: 300s).

Notes: 
- Added flag decoupled-scraping
- Added flag scraping-interval
- Modified main function to decouple scraping (if flag activated)
- Updated documentation
- Added documentation of concurrency flags