### PR TITLE
Use get metrics list

### DIFF
--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -361,7 +361,8 @@ func getMetricsList(dimensions []*cloudwatch.Dimension, serviceName *string, met
 		if err != nil {
 			log.Fatal(err)
 		}
-		resp = filterMetricsBasedOnDimensions(dimensions, &res)
+		//resp = filterMetricsBasedOnDimensions(dimensions, &res)
+		return resp
 	} else {
 		resp = createListMetricsOutput(dimensions, getNamespace(serviceName), &metric.Name)
 	}
@@ -436,7 +437,8 @@ func detectDimensionsByService(service *string, resourceArn *string, clientCloud
 	case "rds":
 		dimensions = buildBaseDimension(arnParsed.Resource, "DBInstanceIdentifier", "db:")
 	case "s3":
-		dimensions = buildBaseDimension(arnParsed.Resource, "BucketName", "")
+		//dimensions = buildBaseDimension(arnParsed.Resource, "BucketName", "")
+		break
 	case "sqs":
 		dimensions = buildBaseDimension(arnParsed.Resource, "QueueName", "")
 	case "vpn":

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -52,6 +52,11 @@ func createCloudwatchSession(region *string, roleArn string) *cloudwatch.CloudWa
 	maxCloudwatchRetries := 5
 
 	config := &aws.Config{Region: region, MaxRetries: &maxCloudwatchRetries}
+
+	if *debug {
+		config.LogLevel = aws.LogLevel(aws.LogDebugWithHTTPBody)
+	}
+
 	if roleArn != "" {
 		config.Credentials = stscreds.NewCredentials(sess, roleArn)
 	}
@@ -151,7 +156,9 @@ func createListMetricsInput(dimensions []*cloudwatch.Dimension, namespace *strin
 	var dimensionsFilter []*cloudwatch.DimensionFilter
 
 	for _, dim := range dimensions {
-		dimensionsFilter = append(dimensionsFilter, &cloudwatch.DimensionFilter{Name: dim.Name, Value: dim.Value})
+		if dim.Value != nil {
+			dimensionsFilter = append(dimensionsFilter, &cloudwatch.DimensionFilter{Name: dim.Name, Value: dim.Value})
+		}
 	}
 	output = &cloudwatch.ListMetricsInput{
 		MetricName: metricsName,
@@ -209,23 +216,31 @@ func (iface cloudwatchInterface) get(filter *cloudwatch.GetMetricStatisticsInput
 func (iface cloudwatchInterface) getMetricData(filter *cloudwatch.GetMetricDataInput) *cloudwatch.GetMetricDataOutput {
 	c := iface.client
 
+	var resp cloudwatch.GetMetricDataOutput
+
 	if *debug {
 		log.Println(filter)
 	}
 
-	resp, err := c.GetMetricData(filter)
+	// Using the paged version of the function
+	err := c.GetMetricDataPages(filter,
+		func(page *cloudwatch.GetMetricDataOutput, lastPage bool) bool {
+			cloudwatchAPICounter.Inc()
+			cloudwatchGetMetricDataAPICounter.Inc()
+			for _, metricData := range page.MetricDataResults {
+				resp.MetricDataResults = append(resp.MetricDataResults, metricData)
+			}
+			return !lastPage
+		})
 
 	if *debug {
 		log.Println(resp)
 	}
 
-	cloudwatchAPICounter.Inc()
-	cloudwatchGetMetricDataAPICounter.Inc()
-
 	if err != nil {
 		panic(err)
 	}
-	return resp
+	return &resp
 }
 
 func getNamespace(service *string) *string {
@@ -317,17 +332,9 @@ func filterMetricsBasedOnDimensions(dimensions []*cloudwatch.Dimension, resp *cl
 	return &output
 }
 
-func getResourceValue(resourceName string, dimensions []*cloudwatch.Dimension, namespace *string, clientCloudwatch cloudwatchInterface) (dimensionResourceName *string) {
-	c := clientCloudwatch.client
-	filter := createListMetricsInput(dimensions, namespace, nil)
-	req, resp := c.ListMetricsRequest(filter)
-	err := req.Send()
+func getResourceValue(resourceName string, dimensions []*cloudwatch.Dimension, namespace *string, fullMetricsList *cloudwatch.ListMetricsOutput) (dimensionResourceName *string) {
 
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	cloudwatchAPICounter.Inc()
+	resp := filterMetricsBasedOnDimensionsWithValues(dimensions, nil, fullMetricsList)
 	return getDimensionValueForName(resourceName, resp)
 }
 
@@ -361,15 +368,85 @@ func getMetricsList(dimensions []*cloudwatch.Dimension, serviceName *string, met
 		if err != nil {
 			log.Fatal(err)
 		}
-		//resp = filterMetricsBasedOnDimensions(dimensions, &res)
-		return resp
+		resp = filterMetricsBasedOnDimensions(dimensions, &res)
 	} else {
 		resp = createListMetricsOutput(dimensions, getNamespace(serviceName), &metric.Name)
 	}
 	return resp
 }
 
-func queryAvailableDimensions(resource string, namespace *string, clientCloudwatch cloudwatchInterface) (dimensions []*cloudwatch.Dimension) {
+func getFullMetricsList(serviceName *string, metric metric, clientCloudwatch cloudwatchInterface) (resp *cloudwatch.ListMetricsOutput) {
+	c := clientCloudwatch.client
+	filter := createListMetricsInput(nil, getNamespace(serviceName), &metric.Name)
+	var res cloudwatch.ListMetricsOutput
+	err := c.ListMetricsPages(filter,
+		func(page *cloudwatch.ListMetricsOutput, lastPage bool) bool {
+			for _, metric := range page.Metrics {
+				res.Metrics = append(res.Metrics, metric)
+			}
+			return !lastPage
+		})
+	cloudwatchAPICounter.Inc()
+	if err != nil {
+		log.Fatal(err)
+	}
+	return &res
+}
+
+func filterMetricsBasedOnDimensionsWithValues(
+	dimensionsWithValue []*cloudwatch.Dimension,
+	dimensionsWithoutValue []*cloudwatch.Dimension,
+	metricsToFilter *cloudwatch.ListMetricsOutput) *cloudwatch.ListMetricsOutput {
+
+	var numberOfDimensions = len(dimensionsWithValue) + len(dimensionsWithoutValue)
+	var output cloudwatch.ListMetricsOutput
+	for _, metric := range metricsToFilter.Metrics {
+		if len(metric.Dimensions) == numberOfDimensions {
+			shouldAddMetric := true
+			for _, metricDimension := range metric.Dimensions {
+				shouldAddMetric = shouldAddMetric &&
+					(dimensionIsInListWithValues(metricDimension, dimensionsWithValue) ||
+						dimensionIsInListWithoutValues(metricDimension, dimensionsWithoutValue))
+				if shouldAddMetric == false {
+					break
+				}
+			}
+			if shouldAddMetric == true {
+				output.Metrics = append(output.Metrics, metric)
+			}
+		}
+	}
+	return &output
+}
+
+func dimensionIsInListWithValues(
+	dimension *cloudwatch.Dimension,
+	dimensionsList []*cloudwatch.Dimension) bool {
+	if dimensionsList != nil {
+		for _, dimensionInList := range dimensionsList {
+			if *dimension.Name == *dimensionInList.Name &&
+				*dimension.Value == *dimensionInList.Value {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func dimensionIsInListWithoutValues(
+	dimension *cloudwatch.Dimension,
+	dimensionsList []*cloudwatch.Dimension) bool {
+	if dimensionsList != nil {
+		for _, dimensionInList := range dimensionsList {
+			if *dimension.Name == *dimensionInList.Name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func queryAvailableDimensions(resource string, namespace *string, fullMetricsList *cloudwatch.ListMetricsOutput) (dimensions []*cloudwatch.Dimension) {
 
 	if !strings.HasSuffix(*namespace, "ApplicationELB") {
 		log.Fatal("Not implemented queryAvailableDimensions: " + *namespace)
@@ -378,7 +455,7 @@ func queryAvailableDimensions(resource string, namespace *string, clientCloudwat
 
 	if strings.HasPrefix(resource, "targetgroup/") {
 		dimensions = append(dimensions, buildDimension("TargetGroup", resource))
-		loadBalancerName := getResourceValue("LoadBalancer", dimensions, namespace, clientCloudwatch)
+		loadBalancerName := getResourceValue("LoadBalancer", dimensions, namespace, fullMetricsList)
 		if loadBalancerName != nil {
 			dimensions = append(dimensions, buildDimension("LoadBalancer", *loadBalancerName))
 		}
@@ -391,7 +468,7 @@ func queryAvailableDimensions(resource string, namespace *string, clientCloudwat
 	return dimensions
 }
 
-func detectDimensionsByService(service *string, resourceArn *string, clientCloudwatch cloudwatchInterface) (dimensions []*cloudwatch.Dimension) {
+func detectDimensionsByService(service *string, resourceArn *string, fullMetricsList *cloudwatch.ListMetricsOutput) (dimensions []*cloudwatch.Dimension) {
 	arnParsed, err := arn.Parse(*resourceArn)
 
 	if err != nil {
@@ -400,7 +477,7 @@ func detectDimensionsByService(service *string, resourceArn *string, clientCloud
 
 	switch *service {
 	case "alb":
-		dimensions = queryAvailableDimensions(arnParsed.Resource, getNamespace(service), clientCloudwatch)
+		dimensions = queryAvailableDimensions(arnParsed.Resource, getNamespace(service), fullMetricsList)
 	case "asg":
 		dimensions = buildBaseDimension(arnParsed.Resource, "AutoScalingGroupName", "autoScalingGroupName/")
 	case "dynamodb":
@@ -437,7 +514,7 @@ func detectDimensionsByService(service *string, resourceArn *string, clientCloud
 	case "rds":
 		dimensions = buildBaseDimension(arnParsed.Resource, "DBInstanceIdentifier", "db:")
 	case "s3":
-		//dimensions = buildBaseDimension(arnParsed.Resource, "BucketName", "")
+		dimensions = buildBaseDimension(arnParsed.Resource, "BucketName", "")
 		break
 	case "sqs":
 		dimensions = buildBaseDimension(arnParsed.Resource, "QueueName", "")

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ var (
 	showVersion           = flag.Bool("v", false, "prints current yace version.")
 	cloudwatchConcurrency = flag.Int("cloudwatch-concurrency", 5, "Maximum number of concurrent requests to CloudWatch API")
 	tagConcurrency        = flag.Int("tag-concurrency", 5, "Maximum number of concurrent requests to Resource Tagging API")
+	metricsPerQuery       = flag.Int("metrics-per-query", 500, "Number of metrics made in a single GetMetricsData request")
 
 	supportedServices = []string{
 		"alb",

--- a/prometheus.go
+++ b/prometheus.go
@@ -133,6 +133,7 @@ func replaceWithUnderscores(text string) string {
 		"-", "_",
 		":", "_",
 		"=", "_",
+		"“", "_",
 	)
 	return replacer.Replace(text)
 }


### PR DESCRIPTION
This PR solves the following problems: 
- When high number of resources, there were many metrics queried, but not all of them had metrics available (for example, in S3, many resources, but maybe only a bunch of them with metrics enabled).
- In ALB there were many queries for target resources that was causing API throttling.  
- The field 'length' of the metrics is being ignored and causes data not being shown

Solution: 
- Rewrite of the scrapeDiscoveryJobUsingMetricData function to reuse list of resources in all the metrics of the same job and only ask for metrics with data available according to GetMetricsList. This prevent throttling when high number of resources and saves petitions of metrics to the API.
- Changed the petition of targeted resources in ALB to reuse the list of metrics. This prevents throttling when high number of ALB resources configured in AWS account.
- Fixed bug in that function that was ignoring the field legnth of the metric and always using 120s
- Replaced the getMetricsData function to use the paginated version
- Changed the number of metrics asked per getMetricsData API request to a configurable flag and set it to 500 by default (current max. metrics for this function)
- Added “ character to be replaced by _ in replaceWithUnderscores function
- Added debugging option for AWS API calls if debug enabled