### PR TITLE
feat: add cloudfront support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ YACE is currently in quick iteration mode. Things will probably break in upcomin
 * Supported services with auto discovery through tags:
 
   * alb - Application Load Balancer
+  * cf - Cloud Front
   * dynamodb - NoSQL Online Datenbank Service
   * ebs - Elastic Block Storage
   * ec - ElastiCache

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -250,6 +250,8 @@ func getNamespace(service *string) *string {
 		ns = "AWS/ApplicationELB"
 	case "asg":
 		ns = "AWS/AutoScaling"
+	case "cf":
+		ns = "AWS/CloudFront"
 	case "dynamodb":
 		ns = "AWS/DynamoDB"
 	case "ebs":
@@ -486,6 +488,9 @@ func detectDimensionsByService(service *string, resourceArn *string, fullMetrics
 		dimensions = queryAvailableDimensions(arnParsed.Resource, getNamespace(service), fullMetricsList)
 	case "asg":
 		dimensions = buildBaseDimension(arnParsed.Resource, "AutoScalingGroupName", "autoScalingGroupName/")
+	case "cf":
+		dimensions = buildBaseDimension(arnParsed.Resource, "DistributionId", "distribution/")
+		dimensions = append(dimensions, buildDimension("Region", "Global"))
 	case "dynamodb":
 		dimensions = buildBaseDimension(arnParsed.Resource, "TableName", "table/")
 	case "ebs":

--- a/aws_tags.go
+++ b/aws_tags.go
@@ -65,6 +65,8 @@ func (iface tagsInterface) get(job job) (resources []*tagsData, err error) {
 	case "alb":
 		filter = append(filter, aws.String("elasticloadbalancing:loadbalancer"))
 		filter = append(filter, aws.String("elasticloadbalancing:targetgroup"))
+	case "cf":
+		filter = append(filter, aws.String("cloudfront"))
 	case "asg":
 		return iface.getTaggedAutoscalingGroups(job)
 	case "dynamodb":

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ var (
 	supportedServices = []string{
 		"alb",
 		"asg",
+		"cf",
 		"dynamodb",
 		"ebs",
 		"ec",


### PR DESCRIPTION
Closes #140

Implements CloudFront support for auto-discovery.

```
discovery:
  jobs:
  - type: cf
    region: us-east-1
    enableMetricData: true
    searchTags:
      - Key: Environment
        Value: prod
    additionalDimensions:
      - DistributionId
      - Region
    metrics:
      - name: Requests
        statistics: [Sum]
        period: 60
        length: 600
        nilToZero: true
      - name: 4xxErrorRate
        statistics: [Average]
        period: 60
        length: 600
        nilToZero: true
      - name: 5xxErrorRate
        statistics: [Average]
        period: 60
        length: 600
        nilToZero: true
```