### PR TITLE
Latest cloudwatch-exporter requires cloudwatch:GetMetricData permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ The following IAM permissions are required for YACE to work.
 
 ```json
 "tag:GetResources",
+"cloudwatch:GetMetricData",
 "cloudwatch:GetMetricStatistics",
 "cloudwatch:ListMetrics"
 ```


### PR DESCRIPTION
Required IAM permissions changed after https://github.com/ivx/yet-another-cloudwatch-exporter/pull/118