### PR TITLE
Add support for Step Function Execution Metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ config.yml
 yet-another-cloudwatch-exporter
 vendor
 dist
+
+.idea/*

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,3 @@ config.yml
 yet-another-cloudwatch-exporter
 vendor
 dist
-
-.idea/*

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ YACE is currently in quick iteration mode. Things will probably break in upcomin
   * kafka - Managed Apache Kafka
   * firehose - Managed Streaming Service
   * sns - Simple Notification Service
+  * sfn - Step Functions
 
 ## Image
 

--- a/aws_tags.go
+++ b/aws_tags.go
@@ -92,7 +92,7 @@ func (iface tagsInterface) get(job job) (resources []*tagsData, err error) {
 		filter = append(filter, aws.String("es:domain"))
 	case "firehose":
 		filter = append(filter, aws.String("firehose"))
-  case "fsx":
+	case "fsx":
 		filter = append(filter, aws.String("fsx:file-system"))
 	case "kinesis":
 		filter = append(filter, aws.String("kinesis:stream"))
@@ -108,6 +108,8 @@ func (iface tagsInterface) get(job job) (resources []*tagsData, err error) {
 		filter = append(filter, aws.String("route53resolver"))
 	case "s3":
 		filter = append(filter, aws.String("s3"))
+	case "sfn":
+		filter = append(filter, aws.String("states"))
 	case "sns":
 		filter = append(filter, aws.String("sns"))
 	case "sqs":

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ var (
 		"rds",
 		"r53r",
 		"s3",
+		"sfn",
 		"sns",
 		"sqs",
 		"tgw",


### PR DESCRIPTION
Initial Support for Step Function Execution Metrics
See - https://docs.aws.amazon.com/step-functions/latest/dg/procedure-cw-metrics.html#cloudwatch-step-functions-execution-metrics

AWS/States namespace Dimensions for StateMachineArn 

(note - ActivityArn|LambdaFunctionArn|ServiceIntegrationResourceArn and other non-execution metrics are not supported with this change.)