### PR TITLE
support for multiple regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ exportedTagsOnMetrics:
 
 | Key                  | Description                                                                                |
 | -------------------- | ------------------------------------------------------------------------------------------ |
-| region               | AWS region                                                                                 |
+| regions              | List of AWS regions                                                                        |
 | type                 | Service name, e.g. "ec2", "s3", etc.                                                       |
 | length (Default 120) | How far back to request data for in seconds                                                |
 | delay                | If set it will request metrics up until `current_time - d
@@ -116,7 +116,7 @@ searchTags:
 
 | Key        | Description                                                |
 | ---------- | ---------------------------------------------------------- |
-| region     | AWS region                                                 |
+| regions    | List of AWS regions                                        |
 | roleArn    | IAM role to assume                                         |
 | namespace  | CloudWatch namespace                                       |
 | name       | Must be set with multiple block definitions per namespace  |
@@ -134,8 +134,9 @@ discovery:
     ebs:
       - VolumeId
   jobs:
-  - region: eu-west-1
-    type: es
+  - type: es
+    regions:
+      - eu-west-1
     searchTags:
       - Key: type
         Value: ^(easteregg|k8s)$
@@ -161,7 +162,8 @@ discovery:
         period: 600
         length: 60
   - type: elb
-    region: eu-west-1
+    regions:
+      - eu-west-1
     length: 900
     delay: 120
     awsDimensions:
@@ -183,7 +185,8 @@ discovery:
         delay: 300 #(this will be ignored)
         nilToZero: true
   - type: alb
-    region: eu-west-1
+    regions:
+      - eu-west-1
     searchTags:
       - Key: kubernetes.io/service-name
         Value: .*
@@ -193,7 +196,8 @@ discovery:
         period: 60
         length: 600
   - type: vpn
-    region: eu-west-1
+    regions:
+      - eu-west-1
     searchTags:
       - Key: kubernetes.io/service-name
         Value: .*
@@ -204,7 +208,8 @@ discovery:
         period: 60
         length: 300
   - type: kinesis
-    region: eu-west-1
+    regions:
+      - eu-west-1
     metrics:
       - name: PutRecords.Success
         statistics:
@@ -212,7 +217,8 @@ discovery:
         period: 60
         length: 300
   - type: s3
-    region: eu-west-1
+    regions:
+      - eu-west-1
     searchTags:
       - Key: type
         Value: public
@@ -234,7 +240,8 @@ discovery:
           - name: StorageType
             value: StandardStorage
   - type: ebs
-    region: eu-west-1
+    regions:
+      - eu-west-1
     searchTags:
       - Key: type
         Value: public
@@ -246,7 +253,8 @@ discovery:
         length: 600
         addCloudwatchTimestamp: true
   - type: kafka
-    region: eu-west-1
+    regions:
+      - eu-west-1
     searchTags:
       - Key: env
         Value: dev
@@ -262,7 +270,8 @@ discovery:
 static:
   - namespace: AWS/AutoScaling
     name: must_be_set
-    region: eu-west-1
+    regions:
+      - eu-west-1
     dimensions:
      - name: AutoScalingGroupName
        value: Test

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -270,7 +270,7 @@ func getNamespace(service *string) *string {
 		ns = "AWS/ElasticMapReduce"
 	case "es":
 		ns = "AWS/ES"
-  case "firehose":
+	case "firehose":
 		ns = "AWS/Firehose"
 	case "fsx":
 		ns = "AWS/FSx"
@@ -527,7 +527,7 @@ func detectDimensionsByService(service *string, resourceArn *string, fullMetrics
 		dimensions = buildBaseDimension(arnParsed.Resource, "DeliveryStreamName", "deliverystream/")
 	case "fsx":
 		dimensions = buildBaseDimension(arnParsed.Resource, "FileSystemId", "file-system/")
-  case "kinesis":
+	case "kinesis":
 		dimensions = buildBaseDimension(arnParsed.Resource, "StreamName", "stream/")
 	case "lambda":
 		dimensions = buildBaseDimension(arnParsed.Resource, "FunctionName", "function:")

--- a/aws_tags.go
+++ b/aws_tags.go
@@ -92,7 +92,7 @@ func (iface tagsInterface) get(job job) (resources []*tagsData, err error) {
 		filter = append(filter, aws.String("es:domain"))
 	case "firehose":
 		filter = append(filter, aws.String("firehose"))
-  case "fsx":
+	case "fsx":
 		filter = append(filter, aws.String("fsx:file-system"))
 	case "kinesis":
 		filter = append(filter, aws.String("kinesis:stream"))

--- a/aws_tags.go
+++ b/aws_tags.go
@@ -56,7 +56,7 @@ func createASGSession(region *string, roleArn string) autoscalingiface.AutoScali
 	return autoscaling.New(sess, config)
 }
 
-func (iface tagsInterface) get(job job) (resources []*tagsData, err error) {
+func (iface tagsInterface) get(job job, region string) (resources []*tagsData, err error) {
 	c := iface.client
 
 	var filter []*string
@@ -70,7 +70,7 @@ func (iface tagsInterface) get(job job) (resources []*tagsData, err error) {
 	case "cf":
 		filter = append(filter, aws.String("cloudfront"))
 	case "asg":
-		return iface.getTaggedAutoscalingGroups(job)
+		return iface.getTaggedAutoscalingGroups(job, region)
 	case "dynamodb":
 		filter = append(filter, aws.String("dynamodb:table"))
 	case "ebs":
@@ -135,7 +135,7 @@ func (iface tagsInterface) get(job job) (resources []*tagsData, err error) {
 			resource.ID = resourceTagMapping.ResourceARN
 
 			resource.Service = &job.Type
-			resource.Region = &job.Region
+			resource.Region = &region
 
 			for _, t := range resourceTagMapping.Tags {
 				resource.Tags = append(resource.Tags, &tag{Key: *t.Key, Value: *t.Value})
@@ -150,7 +150,7 @@ func (iface tagsInterface) get(job job) (resources []*tagsData, err error) {
 }
 
 // Once the resourcemappingapi supports ASGs then this workaround method can be deleted
-func (iface tagsInterface) getTaggedAutoscalingGroups(job job) (resources []*tagsData, err error) {
+func (iface tagsInterface) getTaggedAutoscalingGroups(job job, region string) (resources []*tagsData, err error) {
 	ctx := context.Background()
 	pageNum := 0
 	return resources, iface.asgClient.DescribeAutoScalingGroupsPagesWithContext(ctx, &autoscaling.DescribeAutoScalingGroupsInput{},
@@ -166,7 +166,7 @@ func (iface tagsInterface) getTaggedAutoscalingGroups(job job) (resources []*tag
 				resource.ID = aws.String(fmt.Sprintf("arn:aws:autoscaling:%s:%s:%s", parts[3], parts[4], parts[7]))
 
 				resource.Service = &job.Type
-				resource.Region = &job.Region
+				resource.Region = &region
 
 				for _, t := range asg.Tags {
 					resource.Tags = append(resource.Tags, &tag{Key: *t.Key, Value: *t.Value})

--- a/config.go
+++ b/config.go
@@ -21,7 +21,6 @@ type discovery struct {
 type exportedTagsOnMetrics map[string][]string
 
 type job struct {
-	Region        string   `yaml:"region"`
 	Regions       []string `yaml:"regions"`
 	Type          string   `yaml:"type"`
 	RoleArn       string   `yaml:"roleArn"`
@@ -34,7 +33,6 @@ type job struct {
 
 type static struct {
 	Name       string      `yaml:"name"`
-	Region     string      `yaml:"region"`
 	Regions    []string    `yaml:"regions"`
 	RoleArn    string      `yaml:"roleArn"`
 	Namespace  string      `yaml:"namespace"`

--- a/config.go
+++ b/config.go
@@ -22,6 +22,7 @@ type exportedTagsOnMetrics map[string][]string
 
 type job struct {
 	Region        string   `yaml:"region"`
+	Regions       []string `yaml:"regions"`
 	Type          string   `yaml:"type"`
 	RoleArn       string   `yaml:"roleArn"`
 	AwsDimensions []string `yaml:"awsDimensions"`
@@ -34,6 +35,7 @@ type job struct {
 type static struct {
 	Name       string      `yaml:"name"`
 	Region     string      `yaml:"region"`
+	Regions    []string    `yaml:"regions"`
 	RoleArn    string      `yaml:"roleArn"`
 	Namespace  string      `yaml:"namespace"`
 	CustomTags []tag       `yaml:"customTags"`


### PR DESCRIPTION
Supports:

- `discovery.job[].regions`
- `static[].regions`

to allow specifying multiple regions.  

This new property overrides `region` only if `region` is not specified.