### PR TITLE
initial ApiGateway support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ YACE is currently in quick iteration mode. Things will probably break in upcomin
 * Supported services with auto discovery through tags:
 
   * alb - Application Load Balancer
+  * apigateway - Api Gateway
   * appsync - AppSync
   * cf - Cloud Front
   * dynamodb - NoSQL Online Datenbank Service

--- a/abstract.go
+++ b/abstract.go
@@ -42,6 +42,7 @@ func scrapeAwsData(config conf) ([]*tagsData, []*cloudwatchData) {
 				clientTag := tagsInterface{
 					client:    createTagSession(region, roleArn),
 					asgClient: createASGSession(region, roleArn),
+					apiGatewayClient: createAPIGatewaySession(region, roleArn),
 				}
 				var resources []*tagsData
 				var metrics []*cloudwatchData
@@ -186,7 +187,7 @@ func scrapeDiscoveryJobUsingMetricData(
 			metricTags := resource.metricTags(tagsOnMetrics)
 
 			// Creates the dimensions with values for the resource depending on the namespace of the job (p.e. InstanceId=XXXXXXX)
-			dimensionsWithValue := detectDimensionsByService(resource.Service, resource.ID, fullMetricsList)
+			dimensionsWithValue := detectDimensionsByService(resource.Service, resource, fullMetricsList)
 
 			// Adds the dimensions with values of that specific metric of the job
 			dimensionsWithValue = addAdditionalDimensions(dimensionsWithValue, metric.AdditionalDimensions)

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ var (
 
 	supportedServices = []string{
 		"alb",
+		"apigateway",
 		"appsync",
 		"asg",
 		"cf",
@@ -82,7 +83,7 @@ func updateMetrics(registry *prometheus.Registry) {
 	metrics = append(metrics, migrateTagsToPrometheus(tagsData)...)
 
 	registry.MustRegister(NewPrometheusCollector(metrics))
-	for _, counter := range []prometheus.Counter{cloudwatchAPICounter, cloudwatchGetMetricDataAPICounter, cloudwatchGetMetricStatisticsAPICounter, resourceGroupTaggingAPICounter, autoScalingAPICounter} {
+	for _, counter := range []prometheus.Counter{cloudwatchAPICounter, cloudwatchGetMetricDataAPICounter, cloudwatchGetMetricStatisticsAPICounter, resourceGroupTaggingAPICounter, autoScalingAPICounter, apiGatewayAPICounter} {
 		if err := registry.Register(counter); err != nil {
 			log.Warning("Could not publish cloudwatch api metric")
 		}

--- a/prometheus.go
+++ b/prometheus.go
@@ -30,6 +30,10 @@ var (
 		Name: "yace_cloudwatch_autoscalingapi_requests_total",
 		Help: "Help is not implemented yet.",
 	})
+	apiGatewayAPICounter = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "yace_cloudwatch_apigatewayapi_requests_total",
+		Help: "Help is not implemented yet.",
+	})
 )
 
 type PrometheusMetric struct {


### PR DESCRIPTION
Initial support for api gateway.

The challenges with capturing these metrics:

The Arns for api gateway are based off the Ids, NOT the names.
The cloudwatch metric dimensions use the name, not the ID.
This makes it impossible to associate the IDs returned by the resource tagging API with the names metric dimensions without some changes.
See - https://docs.aws.amazon.com/apigateway/latest/developerguide/arn-format-reference.html

What I did to support this:
Describe the api gateways using *WithContext background calls.
The api names are put in a "Matcher" property on the Resource Object.
The thought being that the ID can stay as the ID but a custom property could be used to do the lookup/matching/association between the cloudwatch metric dimension and the tagged object.

There are additional properties in the ARN for stage/method/resource which have unique metrics.
Ex. GET vs POST, qa vs prod - each have their own metrics
See - https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-metrics-and-dimensions.html
See - https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-logging.html
It would be difficult to capture these using the existing additionalDimensions property, because the values are dynamic.


What I did to support this:
These api gateway dimensions are also in the ARNs.
I dynamically add the dimensions by parsing the ARNs.  That allows the matching of dimension counts and dimension names/values to successfully associate and lookup these metrics.
The problem with that is that prometheus won't allow you register a collector where the labels don't exist on all the metrics.
So for all api gateway metrics, empty strings are added to the api metrics for the stage/method/resource if they aren't set.