### PR TITLE
add service name translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,17 @@ YACE is currently in quick iteration mode. Things will probably break in upcomin
 
 ### Top level configuration
 
-| Key       | Description                   |
-| --------- | ----------------------------- |
-| discovery | Auto-discovery configuration  |
-| static    | List of static configurations |
+| Key          | Description                                              |
+| ------------ | -------------------------------------------------------- |
+| discovery    | Auto-discovery configuration                             |
+| static       | List of static configurations                            |
+| translations | A list of name -> value mapping for output compatibility |
+
+### Translations configuration
+
+| Key      | Description                             |
+| -------- | --------------------------------------- |
+| services | A map of service names -> output values |
 
 ### Auto-discovery configuration
 
@@ -128,6 +135,9 @@ searchTags:
 ### Example of config File
 
 ```yaml
+translations:
+  services:
+    ec: elasticache
 discovery:
   exportedTagsOnMetrics:
     ec2:

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -626,6 +626,11 @@ func fixServiceName(serviceName *string, dimensions []*cloudwatch.Dimension) str
 			}
 		}
 	}
+
+    if svcTranslation, ok := config.Translations.Services[*serviceName]; ok {
+        *serviceName = svcTranslation
+    }
+
 	return promString(*serviceName) + suffixName
 }
 

--- a/config.go
+++ b/config.go
@@ -9,8 +9,13 @@ import (
 )
 
 type conf struct {
-	Discovery discovery `yaml:"discovery"`
-	Static    []static  `yaml:"static"`
+	Discovery           discovery   `yaml:"discovery"`
+	Static              []static    `yaml:"static"`
+	Translations        translation `yaml:"translations"`
+}
+
+type translation struct {
+    Services      map[string]string `yaml:"services"`
 }
 
 type discovery struct {


### PR DESCRIPTION
When trying to replace an existing exporter it is good to be able to make the replacement a "drop-in" replacement for the old exporter.  This PR adds the ability to translation service names in the metrics output to a list of specified service names instead of their defaults.