### PR TITLE
Transit Gateway Attachment Metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,3 @@ config.yml
 yet-another-cloudwatch-exporter
 vendor
 dist
-yace
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ yet-another-cloudwatch-exporter
 vendor
 dist
 yace
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ config.yml
 yet-another-cloudwatch-exporter
 vendor
 dist
+yace

--- a/README.md
+++ b/README.md
@@ -338,6 +338,14 @@ The following IAM permissions are required for YACE to work.
 "cloudwatch:ListMetrics"
 ```
 
+The following IAM permissions are required for the transit gateway attachment (twga) metrics to work.
+```json
+"ec2:DescribeTags",
+"ec2:DescribeInstances",
+"ec2:DescribeRegions",
+"ec2:DescribeTransitGateway*"
+```
+
 ## Running locally
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ YACE is currently in quick iteration mode. Things will probably break in upcomin
   * s3 - Object Storage
   * sqs - Simple Queue Service
   * tgw - Transit Gateway
+  * tgwa - Transit Gateway Attachments
   * vpn - VPN connection
   * asg - Auto Scaling Group
   * kafka - Managed Apache Kafka

--- a/abstract.go
+++ b/abstract.go
@@ -42,6 +42,7 @@ func scrapeAwsData(config conf) ([]*tagsData, []*cloudwatchData) {
 				clientTag := tagsInterface{
 					client:    createTagSession(region, roleArn),
 					asgClient: createASGSession(region, roleArn),
+					ec2Client: createEC2Session(region, roleArn),
 				}
 				var resources []*tagsData
 				var metrics []*cloudwatchData

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -488,7 +488,7 @@ func queryAvailableDimensions(resource string, namespace *string, fullMetricsLis
 func detectDimensionsByService(service *string, resourceArn *string, fullMetricsList *cloudwatch.ListMetricsOutput) (dimensions []*cloudwatch.Dimension) {
 	arnParsed, err := arn.Parse(*resourceArn)
 
-	if err != nil {
+	if err != nil && *service != "tgwa" {
 		log.Warning(err)
 		return (dimensions)
 	}
@@ -559,11 +559,13 @@ func detectDimensionsByService(service *string, resourceArn *string, fullMetrics
 		dimensions = buildBaseDimension(arnParsed.Resource, "QueueName", "")
 	case "tgw":
 		dimensions = buildBaseDimension(arnParsed.Resource, "TransitGateway", "transit-gateway/")
-  case "tgwa":
+    case "tgwa":
+		fmt.Printf("log_test_attach_arn: %s\n", *resourceArn)
 		fmt.Printf("log_test_attach_arn: %s\n", arnParsed.Resource)
-		parsedResource := strings.Split(arnParsed.Resource, "/")
+		parsedResource := strings.Split(*resourceArn, "/")
+		fmt.Printf("log_test_attach_parsed: %s\n", parsedResource)
 		dimensions = append(dimensions, buildDimension("TransitGateway", parsedResource[0]), buildDimension("TransitGatewayAttachment", parsedResource[1]))
-		fmt.Printf("log_test_attach: %s\n", dimensions)
+	    fmt.Printf("log_test_attach: %s\n", dimensions)
 	case "vpn":
 		dimensions = buildBaseDimension(arnParsed.Resource, "VpnId", "vpn-connection/")
 	case "kafka":

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -558,14 +558,14 @@ func detectDimensionsByService(service *string, resourceArn *string, fullMetrics
 	case "sqs":
 		dimensions = buildBaseDimension(arnParsed.Resource, "QueueName", "")
 	case "tgw":
-    dimensions = buildBaseDimension(arnParsed.Resource, "TransitGateway", "transit-gateway/")
-		fmt.Printf("log_test_tgw: %s\n", dimensions)
-		fmt.Printf("log_test_tgw_arn: %s\n", arnParsed.Resource)
+		dimensions = buildBaseDimension(arnParsed.Resource, "TransitGateway", "transit-gateway/")
+		// fmt.Printf("log_test_tgw: %s\n", dimensions)
+		// fmt.Printf("log_test_tgw_arn: %s\n", arnParsed.Resource)
   case "tgwa":
 		dimensions = buildBaseDimension(arnParsed.Resource, "TransitGatewayAttachment", "transit-gateway-attachment/")
 		dimensions = append(dimensions, buildDimension("TransitGateway", "tgw-0fd0668aa94cf4827"))
-		fmt.Printf("log_test_attach: %s\n", dimensions)
-		fmt.Printf("log_test_attach_arn: %s\n", arnParsed)
+		// fmt.Printf("log_test_attach: %s\n", dimensions)
+		// fmt.Printf("log_test_attach_arn: %s\n", arnParsed)
 	case "vpn":
 		dimensions = buildBaseDimension(arnParsed.Resource, "VpnId", "vpn-connection/")
 	case "kafka":

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -559,13 +559,11 @@ func detectDimensionsByService(service *string, resourceArn *string, fullMetrics
 		dimensions = buildBaseDimension(arnParsed.Resource, "QueueName", "")
 	case "tgw":
 		dimensions = buildBaseDimension(arnParsed.Resource, "TransitGateway", "transit-gateway/")
-		// fmt.Printf("log_test_tgw: %s\n", dimensions)
-		// fmt.Printf("log_test_tgw_arn: %s\n", arnParsed.Resource)
   case "tgwa":
-		dimensions = buildBaseDimension(arnParsed.Resource, "TransitGatewayAttachment", "transit-gateway-attachment/")
-		dimensions = append(dimensions, buildDimension("TransitGateway", "tgw-0fd0668aa94cf4827"))
-		// fmt.Printf("log_test_attach: %s\n", dimensions)
-		// fmt.Printf("log_test_attach_arn: %s\n", arnParsed)
+		fmt.Printf("log_test_attach_arn: %s\n", arnParsed.Resource)
+		parsedResource := strings.Split(arnParsed.Resource, "/")
+		dimensions = append(dimensions, buildDimension("TransitGateway", parsedResource[0]), buildDimension("TransitGatewayAttachment", parsedResource[1]))
+		fmt.Printf("log_test_attach: %s\n", dimensions)
 	case "vpn":
 		dimensions = buildBaseDimension(arnParsed.Resource, "VpnId", "vpn-connection/")
 	case "kafka":

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -560,12 +560,8 @@ func detectDimensionsByService(service *string, resourceArn *string, fullMetrics
 	case "tgw":
 		dimensions = buildBaseDimension(arnParsed.Resource, "TransitGateway", "transit-gateway/")
     case "tgwa":
-		fmt.Printf("log_test_attach_arn: %s\n", *resourceArn)
-		fmt.Printf("log_test_attach_arn: %s\n", arnParsed.Resource)
 		parsedResource := strings.Split(*resourceArn, "/")
-		fmt.Printf("log_test_attach_parsed: %s\n", parsedResource)
 		dimensions = append(dimensions, buildDimension("TransitGateway", parsedResource[0]), buildDimension("TransitGatewayAttachment", parsedResource[1]))
-	    fmt.Printf("log_test_attach: %s\n", dimensions)
 	case "vpn":
 		dimensions = buildBaseDimension(arnParsed.Resource, "VpnId", "vpn-connection/")
 	case "kafka":

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -298,6 +298,8 @@ func getNamespace(service *string) *string {
 		ns = "AWS/SQS"
 	case "tgw":
 		ns = "AWS/TransitGateway"
+	case "tgwa":
+		ns = "AWS/TransitGateway"
 	case "vpn":
 		ns = "AWS/VPN"
 	default:
@@ -556,7 +558,14 @@ func detectDimensionsByService(service *string, resourceArn *string, fullMetrics
 	case "sqs":
 		dimensions = buildBaseDimension(arnParsed.Resource, "QueueName", "")
 	case "tgw":
-		dimensions = buildBaseDimension(arnParsed.Resource, "TransitGateway", "transit-gateway/")
+    dimensions = buildBaseDimension(arnParsed.Resource, "TransitGateway", "transit-gateway/")
+		fmt.Printf("log_test_tgw: %s\n", dimensions)
+		fmt.Printf("log_test_tgw_arn: %s\n", arnParsed.Resource)
+  case "tgwa":
+		dimensions = buildBaseDimension(arnParsed.Resource, "TransitGatewayAttachment", "transit-gateway-attachment/")
+		dimensions = append(dimensions, buildDimension("TransitGateway", "tgw-0fd0668aa94cf4827"))
+		fmt.Printf("log_test_attach: %s\n", dimensions)
+		fmt.Printf("log_test_attach_arn: %s\n", arnParsed)
 	case "vpn":
 		dimensions = buildBaseDimension(arnParsed.Resource, "VpnId", "vpn-connection/")
 	case "kafka":

--- a/aws_tags.go
+++ b/aws_tags.go
@@ -39,9 +39,7 @@ func createTagSession(region *string, roleArn string) *r.ResourceGroupsTaggingAP
 	maxResourceGroupTaggingRetries := 5
 	config := &aws.Config{Region: region, MaxRetries: &maxResourceGroupTaggingRetries}
 	if roleArn != "" {
-		log.Warnf("log - getTaggedTransitGatewayAttachments - 5 arn %s " , roleArn)
 		config.Credentials = stscreds.NewCredentials(sess, roleArn)
-		log.Warnf("log - getTaggedTransitGatewayAttachments - 5 cred %s " , config.Credentials)
 	}
 
 	return r.New(sess, config)
@@ -69,9 +67,7 @@ func createEC2Session(region *string, roleArn string) ec2iface.EC2API {
 	maxEC2APIRetries := 10
 	config := &aws.Config{Region: region, MaxRetries: &maxEC2APIRetries}
 	if roleArn != "" {
-		log.Warnf("log - getTaggedTransitGatewayAttachments - 4 arn %s " , roleArn)
 		config.Credentials = stscreds.NewCredentials(sess, roleArn)
-		log.Warnf("log - getTaggedTransitGatewayAttachments - 4 cred %s " , config.Credentials)
 	}
 
 	return ec2.New(sess, config)
@@ -206,17 +202,14 @@ func (iface tagsInterface) getTaggedAutoscalingGroups(job job, region string) (r
 }
 
 func (iface tagsInterface) getTaggedTransitGatewayAttachments(job job, region string) (resources []*tagsData, err error) {
-	log.Warnf("log - getTaggedTransitGatewayAttachments - 1")
 	ctx := context.Background()
 	pageNum := 0
 	return resources, iface.ec2Client.DescribeTransitGatewayAttachmentsPagesWithContext(ctx, &ec2.DescribeTransitGatewayAttachmentsInput{},
 		func(page *ec2.DescribeTransitGatewayAttachmentsOutput, more bool) bool {
-			log.Warnf("log - getTaggedTransitGatewayAttachments - 2")
 			pageNum++
 			ec2APICounter.Inc()
 
 			for _, tgwa := range page.TransitGatewayAttachments {
-				log.Warnf("log - getTaggedTransitGatewayAttachments - 3 %s %s", *tgwa.TransitGatewayId, *tgwa.TransitGatewayAttachmentId)
 				resource := tagsData{}
 
 				resource.ID = aws.String(fmt.Sprintf("%s/%s", *tgwa.TransitGatewayId, *tgwa.TransitGatewayAttachmentId))

--- a/aws_tags.go
+++ b/aws_tags.go
@@ -116,6 +116,8 @@ func (iface tagsInterface) get(job job, region string) (resources []*tagsData, e
 		filter = append(filter, aws.String("sqs"))
 	case "tgw":
 		filter = append(filter, aws.String("ec2:transit-gateway"))
+	case "tgwa":
+		filter = append(filter, aws.String("ec2:transit-gateway-attachment"))
 	case "vpn":
 		filter = append(filter, aws.String("ec2:vpn-connection"))
 	case "kafka":

--- a/main.go
+++ b/main.go
@@ -54,6 +54,7 @@ var (
 		"sns",
 		"sqs",
 		"tgw",
+		"tgwa",
 		"vpn",
 	}
 

--- a/prometheus.go
+++ b/prometheus.go
@@ -30,6 +30,10 @@ var (
 		Name: "yace_cloudwatch_autoscalingapi_requests_total",
 		Help: "Help is not implemented yet.",
 	})
+	ec2APICounter = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "yace_cloudwatch_ec2api_requests_total",
+		Help: "Help is not implemented yet.",
+	})
 )
 
 type PrometheusMetric struct {


### PR DESCRIPTION
Method to get transit gateway attachment metrics

Does api call so requires the following IAM perms, this is due to the metric requiring both the TransitGateway and TransitGatewayAttachment dimensions to be presented at query time

```json
"ec2:DescribeTags",
"ec2:DescribeInstances",
"ec2:DescribeRegions",
"ec2:DescribeTransitGateway*"
```

