### PR TITLE
Use 'go fmt' for formatting

### DIFF
--- a/abstract.go
+++ b/abstract.go
@@ -147,9 +147,9 @@ func scrapeDiscoveryJobUsingMetricData(
 
 	// Set a default period
 	if job.Period == 0 {
-	    jobPeriod = 300
+		jobPeriod = 300
 	} else {
-	    jobPeriod = job.Period
+		jobPeriod = job.Period
 	}
 
 	tagSemaphore <- struct{}{}
@@ -209,8 +209,8 @@ func scrapeDiscoveryJobUsingMetricData(
 						id := fmt.Sprintf("id_%d", rand.Int())
 
 						period := int64(jobPeriod)
-						if(metric.Period != 0) {
-						    period = int64(metric.Period)
+						if metric.Period != 0 {
+							period = int64(metric.Period)
 						}
 						addCloudwatchTimestamp := job.AddCloudwatchTimestamp || metric.AddCloudwatchTimestamp
 

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -351,15 +351,15 @@ func filterMetricsBasedOnDimensions(dimensions []*cloudwatch.Dimension, resp *cl
 }
 
 func filterDimensionsWithoutValueByDimensionsWithValue(
-    dimensionsWithoutValue []*cloudwatch.Dimension,
-    dimensionsWithValue []*cloudwatch.Dimension) (dimensions []*cloudwatch.Dimension) {
+	dimensionsWithoutValue []*cloudwatch.Dimension,
+	dimensionsWithValue []*cloudwatch.Dimension) (dimensions []*cloudwatch.Dimension) {
 
-    for _, dimension := range dimensionsWithoutValue {
-        if ! dimensionIsInListWithoutValues(dimension, dimensionsWithValue) {
-            dimensions = append(dimensions, dimension)
-        }
-    }
-    return dimensions
+	for _, dimension := range dimensionsWithoutValue {
+		if !dimensionIsInListWithoutValues(dimension, dimensionsWithValue) {
+			dimensions = append(dimensions, dimension)
+		}
+	}
+	return dimensions
 }
 
 func getAwsDimensions(job job) (dimensions []*cloudwatch.Dimension) {
@@ -575,7 +575,7 @@ func detectDimensionsByService(service *string, resourceArn *string, fullMetrics
 		dimensions = buildBaseDimension(arnParsed.Resource, "QueueName", "")
 	case "tgw":
 		dimensions = buildBaseDimension(arnParsed.Resource, "TransitGateway", "transit-gateway/")
-    case "tgwa":
+	case "tgwa":
 		parsedResource := strings.Split(*resourceArn, "/")
 		dimensions = append(dimensions, buildDimension("TransitGateway", parsedResource[0]), buildDimension("TransitGatewayAttachment", parsedResource[1]))
 	case "vpn":

--- a/config.go
+++ b/config.go
@@ -21,17 +21,17 @@ type discovery struct {
 type exportedTagsOnMetrics map[string][]string
 
 type job struct {
-	Regions                 []string `yaml:"regions"`
-	Type                    string   `yaml:"type"`
-	RoleArns                []string `yaml:"roleArns"`
-	AwsDimensions           []string `yaml:"awsDimensions"`
-	SearchTags              []tag    `yaml:"searchTags"`
-	CustomTags              []tag    `yaml:"customTags"`
-	Metrics                 []metric `yaml:"metrics"`
-	Length                  int      `yaml:"length"`
-	Delay                   int      `yaml:"delay"`
-  Period                  int      `yaml:"period"`
-	AddCloudwatchTimestamp  bool     `yaml:"addCloudwatchTimestamp"`
+	Regions                []string `yaml:"regions"`
+	Type                   string   `yaml:"type"`
+	RoleArns               []string `yaml:"roleArns"`
+	AwsDimensions          []string `yaml:"awsDimensions"`
+	SearchTags             []tag    `yaml:"searchTags"`
+	CustomTags             []tag    `yaml:"customTags"`
+	Metrics                []metric `yaml:"metrics"`
+	Length                 int      `yaml:"length"`
+	Delay                  int      `yaml:"delay"`
+	Period                 int      `yaml:"period"`
+	AddCloudwatchTimestamp bool     `yaml:"addCloudwatchTimestamp"`
 }
 
 type static struct {

--- a/prometheus.go
+++ b/prometheus.go
@@ -123,9 +123,9 @@ func promString(text string) string {
 }
 
 func promStringTag(text string) string {
-    if *labelsSnakeCase {
-        return promString(text)
-    }
+	if *labelsSnakeCase {
+		return promString(text)
+	}
 	return replaceWithUnderscores(text)
 }
 


### PR DESCRIPTION
Using `go fmt` command would provide easy single truth on spaces vs. tabs and related issues.