### PR TITLE
Collect period handling into one method

### DIFF
--- a/abstract.go
+++ b/abstract.go
@@ -142,7 +142,7 @@ func getMetricDataInputLength(job job) int {
 	return length
 }
 
-func metricPeriod(job job, metric metric) int64 {
+func getMetricPeriod(job job, metric metric) int64 {
 	if metric.Period != 0 {
 		return int64(metric.Period)
 	}
@@ -238,7 +238,7 @@ func scrapeDiscoveryJobUsingMetricData(
 							CustomTags:             job.CustomTags,
 							Dimensions:             fetchedMetrics.Dimensions,
 							Region:                 &region,
-							Period:                 metricPeriod(job, metric),
+							Period:                 getMetricPeriod(job, metric),
 						})
 						mux.Unlock()
 					}

--- a/abstract.go
+++ b/abstract.go
@@ -162,14 +162,6 @@ func scrapeDiscoveryJobUsingMetricData(
 	mux := &sync.Mutex{}
 	var wg sync.WaitGroup
 	var getMetricDatas []cloudwatchData
-	var length int
-
-	// Why is this here? 120?
-	if job.Length == 0 {
-		length = 120
-	} else {
-		length = job.Length
-	}
 
 	tagSemaphore <- struct{}{}
 	resources, err := clientTag.get(job, region)

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -41,7 +41,7 @@ type cloudwatchData struct {
 	Tags                    []tag
 	Dimensions              []*cloudwatch.Dimension
 	Region                  *string
-	Period                  *int64
+	Period                  int64
 }
 
 func createCloudwatchSession(region *string, roleArn string) *cloudwatch.CloudWatch {
@@ -120,19 +120,19 @@ func findGetMetricDataById(getMetricDatas []cloudwatchData, value string) (cloud
 func createGetMetricDataInput(getMetricData []cloudwatchData, namespace *string, length int, delay int) (output *cloudwatch.GetMetricDataInput) {
 	var metricsDataQuery []*cloudwatch.MetricDataQuery
 	for _, data := range getMetricData {
-		meticStat := &cloudwatch.MetricStat{
+		metricStat := &cloudwatch.MetricStat{
 			Metric: &cloudwatch.Metric{
 				Dimensions: data.Dimensions,
 				MetricName: data.Metric,
 				Namespace:  namespace,
 			},
-			Period: data.Period,
+			Period: &data.Period,
 			Stat:   &data.Statistics[0],
 		}
 		ReturnData := true
 		metricsDataQuery = append(metricsDataQuery, &cloudwatch.MetricDataQuery{
 			Id:         data.MetricID,
-			MetricStat: meticStat,
+			MetricStat: metricStat,
 			ReturnData: &ReturnData,
 		})
 


### PR DESCRIPTION
Right now `scrapeDiscoveryJobUsingMetricData` addresses `period` related variables on lines 139, 148-154, 211-214 and 230, so there are almost 100 lines between first and last reference. I would like to combine them into one method. And to make simpler, I would pass it around as int64 variable until we have to pass it as *int64 to AWS SDK.

Changes on `filterMetricsBasedOnDimensions` and `detectDimensionsByService` methods are kind of related to https://github.com/ivx/yet-another-cloudwatch-exporter/pull/198