### PR TITLE
Added notion about breaking change for next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# 0.19.0-alpha (unreleased)
+* *BREAKING CHANGE* Add support for multiple roleArns (jylitalo)
+```yaml
+# Before
+---
+discovery:
+  jobs:
+  - type: rds
+    roleArn: "arn:aws:iam::123456789012:role/Prometheus"
+# After
+discovery:
+  jobs:
+  - type: rds
+    roleArns:
+    - "arn:aws:iam::123456789012:role/Prometheus"
+```
+
 # 0.18.0-alpha
 * *BREAKING CHANGE* Add support for multiple regions (goya)
 ```yaml


### PR DESCRIPTION
It would seem that in past CHANGELOG.md has been updated, when release goes out.
Just wanted to suggest that it might make sense to update it when new things go into master branch (like they do it in [hashicorp/terraform](https://github.com/hashicorp/terraform/blob/master/CHANGELOG.md)).