### PR TITLE
set prometheus client to ignore label differences

### DIFF
--- a/prometheus.go
+++ b/prometheus.go
@@ -54,11 +54,7 @@ func NewPrometheusCollector(metrics []*PrometheusMetric) *PrometheusCollector {
 	}
 }
 
-func (p *PrometheusCollector) Describe(descs chan<- *prometheus.Desc) {
-	for _, metric := range p.metrics {
-		descs <- createDesc(metric)
-	}
-}
+func (p *PrometheusCollector) Describe(descs chan<- *prometheus.Desc) {}
 
 func (p *PrometheusCollector) Collect(metrics chan<- prometheus.Metric) {
 	for _, metric := range p.metrics {


### PR DESCRIPTION
When exporting from cloudwatch you can get into the situation where the same metric key name is exported more than once but with differing sets of label keys attached to the metric.  In the default mode the prometheus client will throw a hard error on this condition.

The clients solution to this situation is to put the client into "unchecked" mode but setting up the Describe function as an empty function.  This internally tot he client disables a number of checks and allows the code creating the metrics to ensure integrity of the metrics.

A goos example of this situation happening is with ECS metrics in which the cpu used for the cluster or for a service have the same metrics name exported but one has an additional label key as part of the exported data.