### PR TITLE
Support downloading config file from S3 bucket

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,12 @@ RUN go build -v -ldflags "-X main.version=$VERSION" -o yace
 FROM alpine:latest
 
 EXPOSE 5000
+
+ENV AWS_REGION eu-west-1
+ENV CONFIG_FILE /tmp/config.yml
+
 ENTRYPOINT ["yace"]
-CMD ["--config.file=/tmp/config.yml"]
+CMD ["--config.file=${CONFIG_FILE}"]
 RUN addgroup -g 1000 exporter && \
     adduser -u 1000 -D -G exporter exporter -h /exporter
 

--- a/config.go
+++ b/config.go
@@ -3,7 +3,12 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
+	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
@@ -65,8 +70,37 @@ type tag struct {
 	Value string `yaml:"Value"`
 }
 
+func (c *conf) s3elements(url string) (bucket, key string) {
+	fields := strings.SplitN(url, "/", 4)
+	if len(fields) < 4 {
+		return "", ""
+	}
+	bucket = fields[2]
+	key = fields[3]
+	return bucket, key
+}
+
+func (c *conf) loadContent(file string) ([]byte, error) {
+	if strings.HasPrefix(file, "s3://") {
+		bucket, key := c.s3elements(file)
+		sess, err := session.NewSession(&aws.Config{})
+		if err != nil {
+			return nil, err
+		}
+		downloader := s3manager.NewDownloader(sess)
+		buf := aws.NewWriteAtBuffer([]byte{})
+		_, err = downloader.Download(buf,
+			&s3.GetObjectInput{
+				Bucket: aws.String(bucket),
+				Key:    aws.String(key),
+			})
+		return buf.Bytes(), err
+	}
+	return ioutil.ReadFile(file)
+}
+
 func (c *conf) load(file *string) error {
-	yamlFile, err := ioutil.ReadFile(*file)
+	yamlFile, err := c.loadContent(*file)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -105,8 +105,9 @@ func main() {
 	}
 
 	log.Println("Parse config..")
-	if err := config.load(configFile); err != nil {
-		log.Fatal("Couldn't read ", *configFile, ": ", err)
+	file := os.ExpandEnv(*configFile)
+	if err := config.load(file); err != nil {
+		log.Fatal("Couldn't read ", file, ": ", err)
 	}
 
 	cloudwatchSemaphore = make(chan struct{}, *cloudwatchConcurrency)


### PR DESCRIPTION
If you are running separate yace instances in test and production, it would be convenient if you would be able to use same docker image in both places and simply tell that download yace config file from `s3://bucket_name/s3_object_key`

The reason, why we have to specify AWS_REGION (you can override that as well when you specify env variable for CONFIG_FILE) is that we have to specify some region for the AWS session that would download the config file from S3 bucket.