### PR TITLE
Separate prometheus labels creation from migrateCloudwatchToPrometheus

### DIFF
--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -647,7 +647,7 @@ func createPrometheusLabels(cwd *cloudwatchData) map[string]string {
 	// Inject the sfn name back as a label
 	switch *cwd.Service {
 	case "sfn":
-		labels["dimension_StateMachineArn"] = getStateMachineNameFromArn(*cwd.ID)
+		labels["dimension_"+promStringTag("StateMachineArn")] = getStateMachineNameFromArn(*cwd.ID)
 	case "apigateway":
 		// The same dimensions are required on all metrics by prometheus
 		for _, key := range []string{"Stage", "Resource", "Method"} {

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -639,12 +639,34 @@ func getStateMachineNameFromArn(resourceArn string) string {
 	return parsedResource[1]
 }
 
-func promLabelExists(promLabels map[string]string, key string) bool {
-	if _, ok := promLabels[key]; ok {
-		return true
-	} else {
-		return false
+func createPrometheusLabels(cwd *cloudwatchData) map[string]string {
+	labels := make(map[string]string)
+	labels["name"] = *cwd.ID
+	labels["region"] = *cwd.Region
+
+	// Inject the sfn name back as a label
+	switch *cwd.Service {
+	case "sfn":
+		labels["dimension_StateMachineArn"] = getStateMachineNameFromArn(*cwd.ID)
+	case "apigateway":
+		// The same dimensions are required on all metrics by prometheus
+		for _, key := range []string{"Stage", "Resource", "Method"} {
+			labels["dimension_"+key] = ""
+		}
 	}
+
+	for _, dimension := range cwd.Dimensions {
+		labels["dimension_"+promStringTag(*dimension.Name)] = *dimension.Value
+	}
+
+	for _, label := range cwd.CustomTags {
+		labels["custom_tag_"+promStringTag(label.Key)] = label.Value
+	}
+	for _, tag := range cwd.Tags {
+		labels["tag_"+promStringTag(tag.Key)] = tag.Value
+	}
+
+	return labels
 }
 
 func migrateCloudwatchToPrometheus(cwd []*cloudwatchData) []*PrometheusMetric {
@@ -725,43 +747,9 @@ func migrateCloudwatchToPrometheus(cwd []*cloudwatchData) []*PrometheusMetric {
 				includeTimestamp = false
 			}
 			if exportedDatapoint != nil {
-				promLabels := make(map[string]string)
-				promLabels["name"] = *c.ID
-
-				for _, label := range c.CustomTags {
-					promLabels["custom_tag_"+promStringTag(label.Key)] = label.Value
-				}
-				for _, tag := range c.Tags {
-					promLabels["tag_"+promStringTag(tag.Key)] = tag.Value
-				}
-
-				for _, dimension := range c.Dimensions {
-					promLabels["dimension_"+promStringTag(*dimension.Name)] = *dimension.Value
-				}
-
-				// Inject the sfn name back as a label
-				switch serviceName {
-				case "sfn":
-					promLabels["dimension_StateMachineArn"] = getStateMachineNameFromArn(*c.ID)
-				case "apigateway":
-					// The same dimensions are required on all metrics by prometheus
-					if !promLabelExists(promLabels, "dimension_Stage") {
-						promLabels["dimension_Stage"] = ""
-					}
-					if !promLabelExists(promLabels, "dimension_Resource") {
-						promLabels["dimension_Resource"] = ""
-					}
-					// only for restapis
-					if !promLabelExists(promLabels, "dimension_Method") {
-						promLabels["dimension_Method"] = ""
-					}
-				}
-
-				promLabels["region"] = *c.Region
-
 				p := PrometheusMetric{
 					name:             &name,
-					labels:           promLabels,
+					labels:           createPrometheusLabels(c),
 					value:            exportedDatapoint,
 					timestamp:        timestamp,
 					includeTimestamp: includeTimestamp,

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -651,7 +651,7 @@ func createPrometheusLabels(cwd *cloudwatchData) map[string]string {
 	case "apigateway":
 		// The same dimensions are required on all metrics by prometheus
 		for _, key := range []string{"Stage", "Resource", "Method"} {
-			labels["dimension_"+key] = ""
+			labels["dimension_"+promStringTag(key)] = ""
 		}
 	}
 


### PR DESCRIPTION
No changes to actual functionality.
First I wanted to simplify promLabels handling on apigateway by putting dimension_Stage, dimension_Resource and dimension_Method (and get rid of promLabelExists function). Then I wanted to put name and region labels next to each others and at the end decided it wouldn't hurt to split whole labeling stuff into separate function.