### PR TITLE
Unit test for config file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ WORKDIR /opt/
 COPY go.mod go.sum ./
 RUN go mod download
 
-Add ./*.go ./
-RUN go test
+COPY ./*.go ./config_test.yml ./
+RUN go test -cover
 
 ENV GOOS linux
 ENV GOARCH amd64

--- a/README.md
+++ b/README.md
@@ -300,6 +300,8 @@ static:
         length: 300
 ```
 
+[Source: [config_test.yml](config_test.yml)]
+
 ## Metrics Examples
 
 ```text

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestConfLoad(t *testing.T) {
+	config = conf{}
+	configFile := "config_test.yml"
+	if err := config.load(&configFile); err != nil {
+		t.Error(err)
+	}
+}

--- a/config_test.yml
+++ b/config_test.yml
@@ -1,0 +1,157 @@
+discovery:
+  exportedTagsOnMetrics:
+    ec2:
+      - Name
+    ebs:
+      - VolumeId
+  jobs:
+  - type: es
+    regions:
+      - eu-west-1
+    searchTags:
+      - Key: type
+        Value: ^(easteregg|k8s)$
+    metrics:
+      - name: FreeStorageSpace
+        statistics:
+        - Sum
+        period: 600
+        length: 60
+      - name: ClusterStatus.green
+        statistics:
+        - Minimum
+        period: 600
+        length: 60
+      - name: ClusterStatus.yellow
+        statistics:
+        - Maximum
+        period: 600
+        length: 60
+      - name: ClusterStatus.red
+        statistics:
+        - Maximum
+        period: 600
+        length: 60
+  - type: elb
+    regions:
+      - eu-west-1
+    length: 900
+    delay: 120
+    awsDimensions:
+     - AvailabilityZone
+    searchTags:
+      - Key: KubernetesCluster
+        Value: production-19
+    metrics:
+      - name: HealthyHostCount
+        statistics:
+        - Minimum
+        period: 600
+        length: 600 #(this will be ignored)
+      - name: HTTPCode_Backend_4XX
+        statistics:
+        - Sum
+        period: 60
+        length: 900 #(this will be ignored)
+        delay: 300 #(this will be ignored)
+        nilToZero: true
+  - type: alb
+    regions:
+      - eu-west-1
+    searchTags:
+      - Key: kubernetes.io/service-name
+        Value: .*
+    metrics:
+      - name: UnHealthyHostCount
+        statistics: [Maximum]
+        period: 60
+        length: 600
+  - type: vpn
+    regions:
+      - eu-west-1
+    searchTags:
+      - Key: kubernetes.io/service-name
+        Value: .*
+    metrics:
+      - name: TunnelState
+        statistics:
+        - p90
+        period: 60
+        length: 300
+  - type: kinesis
+    regions:
+      - eu-west-1
+    metrics:
+      - name: PutRecords.Success
+        statistics:
+        - Sum
+        period: 60
+        length: 300
+  - type: s3
+    regions:
+      - eu-west-1
+    searchTags:
+      - Key: type
+        Value: public
+    metrics:
+      - name: NumberOfObjects
+        statistics:
+          - Average
+        period: 86400
+        length: 172800
+        additionalDimensions:
+          - name: StorageType
+            value: AllStorageTypes
+      - name: BucketSizeBytes
+        statistics:
+          - Average
+        period: 86400
+        length: 172800
+        additionalDimensions:
+          - name: StorageType
+            value: StandardStorage
+  - type: ebs
+    regions:
+      - eu-west-1
+    searchTags:
+      - Key: type
+        Value: public
+    metrics:
+      - name: BurstBalance
+        statistics:
+        - Minimum
+        period: 600
+        length: 600
+        addCloudwatchTimestamp: true
+  - type: kafka
+    regions:
+      - eu-west-1
+    searchTags:
+      - Key: env
+        Value: dev
+    awsDimensions:
+      - Broker ID
+      - Topic
+    metrics:
+      - name: BytesOutPerSec
+        statistics:
+        - Average
+        period: 600
+        length: 600
+static:
+  - namespace: AWS/AutoScaling
+    name: must_be_set
+    regions:
+      - eu-west-1
+    dimensions:
+     - name: AutoScalingGroupName
+       value: Test
+    customTags:
+      - Key: CustomTag
+        Value: CustomValue
+    metrics:
+      - name: GroupInServiceInstances
+        statistics:
+        - Minimum
+        period: 60
+        length: 300


### PR DESCRIPTION
Test that yace can successfully parse the example configuration file. 
Unfortunately, GitHub doesn't provide us tools for keeping an example config file in README.md in sync with config_test.yml.