### PR TITLE
Unwanted behavior with pointers (bug fix to #227)

### DIFF
--- a/abstract.go
+++ b/abstract.go
@@ -191,14 +191,15 @@ func getMetricDataForQueries(
 				for _, fetchedMetrics := range metricsToAdd.Metrics {
 					for _, stats := range metric.Statistics {
 						id := fmt.Sprintf("id_%d", rand.Int())
-
+						name := metric.Name
+						nilToZero := metric.NilToZero
 						getMetricDatas = append(getMetricDatas, cloudwatchData{
 							ID:                     resource.ID,
 							MetricID:               &id,
-							Metric:                 &metric.Name,
+							Metric:                 &name,
 							Service:                resource.Service,
 							Statistics:             []string{stats},
-							NilToZero:              &metric.NilToZero,
+							NilToZero:              &nilToZero,
 							AddCloudwatchTimestamp: &addCloudwatchTimestamp,
 							Tags:                   metricTags,
 							CustomTags:             discoveryJob.CustomTags,


### PR DESCRIPTION
I was caught off-guard on golang's way of handling for loops.
Before the fix, I was trying to fetch four metrics from custom namespace, but only got results from last one on a list.
#227 was pointer to https://github.com/ivx/yet-another-cloudwatch-exporter/pull/227