### PR TITLE
Add support NLB. And fixes.

### DIFF
--- a/abstract.go
+++ b/abstract.go
@@ -40,6 +40,7 @@ func scrapeAwsData(config conf) ([]*tagsData, []*cloudwatchData) {
 						apiGatewayClient: createAPIGatewaySession(&region, roleArn),
 						asgClient:        createASGSession(&region, roleArn),
 						ec2Client:        createEC2Session(&region, roleArn),
+						elbv2Client:      createELBV2Session(&region, roleArn),
 					}
 					var resources []*tagsData
 					var metrics []*cloudwatchData
@@ -185,7 +186,7 @@ func getMetricDataForQueries(
 			commonJobDimensions = filterDimensionsWithoutValueByDimensionsWithValue(commonJobDimensions, dimensionsWithValue)
 
 			metricsToAdd := filterMetricsBasedOnDimensionsWithValues(dimensionsWithValue, commonJobDimensions, fullMetricsList)
-			if metricsToAdd != nil {
+			if metricsToAdd != nil && len(metricsToAdd.Metrics) > 0 {
 				addCloudwatchTimestamp := discoveryJob.AddCloudwatchTimestamp || metric.AddCloudwatchTimestamp
 				metricTags := resource.metricTags(tagsOnMetrics)
 				for _, fetchedMetrics := range metricsToAdd.Metrics {

--- a/aws_tags.go
+++ b/aws_tags.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/aws/aws-sdk-go/service/elbv2"
 	r "github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi/resourcegroupstaggingapiiface"
 	log "github.com/sirupsen/logrus"
@@ -34,6 +35,7 @@ type tagsInterface struct {
 	asgClient        autoscalingiface.AutoScalingAPI
 	apiGatewayClient apigatewayiface.APIGatewayAPI
 	ec2Client        ec2iface.EC2API
+	elbv2Client      elbv2.ELBV2
 }
 
 func createSession(roleArn string, config *aws.Config) *session.Session {
@@ -79,6 +81,11 @@ func createAPIGatewaySession(region *string, roleArn string) apigatewayiface.API
 	return apigateway.New(sess, config)
 }
 
+func createELBV2Session(region *string, roleArn string) elbv2.ELBV2 {
+	config := &aws.Config{Region: region}
+	return *elbv2.New(createSession(roleArn, config), config)
+}
+
 func (iface tagsInterface) get(job job, region string) (resources []*tagsData, err error) {
 	switch job.Type {
 	case "asg":
@@ -107,7 +114,7 @@ func (iface tagsInterface) get(job job, region string) (resources []*tagsData, e
 		"kinesis":               {"kinesis:stream"},
 		"lambda":                {"lambda:function"},
 		"ngw":                   {"ec2:natgateway"},
-		"nlb":                   {"elasticloadbalancing:loadbalancer/net"},
+		"nlb":                   {"elasticloadbalancing:loadbalancer/net", "elasticloadbalancing:targetgroup"},
 		"rds":                   {"rds:db"},
 		"redshift":              {"redshift:cluster"},
 		"r53r":                  {"route53resolver"},
@@ -155,6 +162,47 @@ func (iface tagsInterface) get(job job, region string) (resources []*tagsData, e
 	})
 
 	switch job.Type {
+	case "alb", "nlb":
+		var filteredResources []*tagsData
+		var arnFilter []*string
+		var arnBalancers []*string
+		for _, r := range resources {
+			if strings.Contains(*r.ID, "targetgroup/") {
+				arnFilter = append(arnFilter, aws.String(*r.ID))
+			} else {
+				// Add all resources except target groups
+				filteredResources = append(filteredResources, r)
+				arnBalancers = append(arnBalancers, r.ID)
+			}
+		}
+		describeInput := &elbv2.DescribeTargetGroupsInput{
+			TargetGroupArns: arnFilter,
+		}
+		result, err := iface.elbv2Client.DescribeTargetGroups(describeInput)
+		if err != nil {
+			log.Errorf("Error describeTargetGroups for %s , err: %s", job.Type, err)
+			// Do not clear the resource list. The old behavior.
+			break
+		}
+		for _, tg := range result.TargetGroups {
+			if len(tg.LoadBalancerArns) == 0 {
+				log.Debugf("Not found balancer in targetGroup %s", *tg.TargetGroupArn)
+				continue
+			}
+			for _, balancer := range arnBalancers {
+				for _, b := range tg.LoadBalancerArns {
+					if *balancer == *b {
+						for _, res := range resources {
+							if *res.ID == *tg.TargetGroupArn {
+								filteredResources = append(filteredResources, res)
+								break
+							}
+						}
+					}
+				}
+			}
+		}
+		resources = filteredResources
 	case "apigateway":
 		// Get all the api gateways from aws
 		apiGateways, _ := iface.getTaggedApiGateway()
@@ -174,7 +222,6 @@ func (iface tagsInterface) get(job job, region string) (resources []*tagsData, e
 		}
 		resources = filteredResources
 	}
-
 	return resources, resourcePages
 }
 


### PR DESCRIPTION
Hello!

- support NLB

Config:
```  - type: nlb
    regions:
      - eu-central-1
    period: 60
    delay: 120
    nilToZero: true
    metrics:
      - name: UnHealthyHostCount
        statistics: [Maximum]
      - name: HealthyHostCount
        statistics: [Minimum]
 ```
Before: 
```
aws_nlb_info{name="arn:aws:elasticloadbalancing:*******:******:loadbalancer/net/lb-external/*******",tag_Environment="Production",tag_Group="Default",tag_Name="lb-external"} 0
aws_nlb_info{name="arn:aws:elasticloadbalancing:*******:******:loadbalancer/net/lb-internal/********",tag_Environment="Production",tag_Group="Default",tag_Name="lb-internal"} 0
....
```
After:
```
aws_nlb_info{name="arn:aws:elasticloadbalancing:******:******:loadbalancer/net/lb-external/******",tag_Environment="Production",tag_Group="Default",tag_Groups="",tag_Name="lb-external"} 0
aws_nlb_info{name="arn:aws:elasticloadbalancing:******:******:loadbalancer/net/lb-internal/******",tag_Environment="Production",tag_Group="Default",tag_Groups="",tag_Name="lb-internal"} 0
aws_nlb_info{name="arn:aws:elasticloadbalancing:******:******:targetgroup/nginx-int/******",tag_Environment="",tag_Group="Tcp",tag_Groups="Tcp:Default",tag_Name="nginx-int"} 0
aws_nlb_info{name="arn:aws:elasticloadbalancing:******:******:targetgroup/nginx/******",tag_Environment="",tag_Group="Tcp",tag_Groups="Tcp:Default",tag_Name="nginx"} 0
aws_nlb_tg_healthy_host_count_minimum{dimension_LoadBalancer="net/lb-external/******",dimension_TargetGroup="targetgroup/nginx/******",name="arn:aws:elasticloadbalancing:******:******:targetgroup/nginx/******",region="******"} 3
aws_nlb_tg_healthy_host_count_minimum{dimension_LoadBalancer="net/lb-internal/******",dimension_TargetGroup="targetgroup/nginx-int/******",name="arn:aws:elasticloadbalancing:******:******:targetgroup/nginx-int/******",region="******"} 3
aws_nlb_tg_un_healthy_host_count_maximum{dimension_LoadBalancer="net/lb-external/******",dimension_TargetGroup="targetgroup/nginx/******",name="arn:aws:elasticloadbalancing:******:******:targetgroup/nginx/******",region="******"} 0
aws_nlb_tg_un_healthy_host_count_maximum{dimension_LoadBalancer="net/lb-internal/******",dimension_TargetGroup="targetgroup/nginx-int/******",name="arn:aws:elasticloadbalancing:******:******:targetgroup/nginx-int/******",region="******"} 0
...
```

- Error using variable pointer in a loop (duplicate https://github.com/ivx/yet-another-cloudwatch-exporter/pull/236 but fixed without using new variables)
- Fixed incorrect display of alb, nlb info.
For example, before:
```
aws_alb_info{name="arn:aws:elasticloadbalancing:******:******:targetgroup/test/******",tag_Environment="",tag_Group="Other",tag_Groups="Other:Default",tag_Name="test"} 0     # Target group didn't connect to balancers
aws_alb_info{name="arn:aws:elasticloadbalancing:******:******:targetgroup/nginx-int/******",tag_Environment="",tag_Group="Tcp",tag_Groups="Tcp:Default",tag_Name="nginx-int"} 0                 # Target group connected to NLB.
aws_alb_info{name="arn:aws:elasticloadbalancing:******:******:targetgroup/proxy/******",tag_Environment="",tag_Group="Other",tag_Groups="Other:Default",tag_Name="proxy"} 0               # OK
```
After:
```
aws_alb_info{name="arn:aws:elasticloadbalancing:******:******:targetgroup/proxy/******",tag_Environment="",tag_Group="Other",tag_Groups="Other:Default",tag_Name="proxy"} 0
```