### PR TITLE
Test that all discovery job types are associated to AWS namespace

### DIFF
--- a/abstract.go
+++ b/abstract.go
@@ -164,13 +164,14 @@ func getMetricDataForQueries(
 	// Get the awsDimensions of the job configuration
 	// Common for all the metrics of the job
 	commonJobDimensions := getAwsDimensions(discoveryJob)
+	namespace, _ := getNamespace(discoveryJob.Type)
 	// For every metric of the job
 	for _, metric := range discoveryJob.Metrics {
 		// Get the full list of metrics
 		// This includes, for this metric the possible combinations
 		// of dimensions and value of dimensions with data
 		tagSemaphore <- struct{}{}
-		fullMetricsList := getFullMetricsList(&discoveryJob.Type, metric, clientCloudwatch)
+		fullMetricsList := getFullMetricsList(namespace, metric, clientCloudwatch)
 		<-tagSemaphore
 
 		// For every resource
@@ -222,9 +223,13 @@ func scrapeDiscoveryJobUsingMetricData(
 	clientTag tagsInterface,
 	clientCloudwatch cloudwatchInterface) (resources []*tagsData, cw []*cloudwatchData) {
 
+	namespace, err := getNamespace(job.Type)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
 	// Add the info tags of all the resources
 	tagSemaphore <- struct{}{}
-	resources, err := clientTag.get(job, region)
+	resources, err = clientTag.get(job, region)
 	<-tagSemaphore
 	if err != nil {
 		log.Printf("Couldn't describe resources for region %s: %s\n", region, err.Error())
@@ -247,13 +252,7 @@ func scrapeDiscoveryJobUsingMetricData(
 			if end > metricDataLength {
 				end = metricDataLength
 			}
-			filter := createGetMetricDataInput(
-				getMetricDatas[i:end],
-				getNamespace(resources[0].Service),
-				length,
-				job.Delay,
-			)
-
+			filter := createGetMetricDataInput(getMetricDatas[i:end], &namespace, length, job.Delay)
 			data := clientCloudwatch.getMetricData(filter)
 			if data != nil {
 				for _, MetricDataResult := range data.MetricDataResults {

--- a/aws_cloudwatch_test.go
+++ b/aws_cloudwatch_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
-	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"strings"
 	"testing"
+
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
 )
 
 func TestDimensionsToCliString(t *testing.T) {
@@ -19,5 +21,23 @@ func TestDimensionsToCliString(t *testing.T) {
 	if actual != expected {
 		t.Fatalf("\nexpected: %q\nactual:  %q", expected, actual)
 	}
+}
 
+func TestGetNamespace(t *testing.T) {
+	for _, jobType := range supportedServices {
+		ns, err := getNamespace(jobType)
+		if err != nil {
+			t.Fatalf("jobType %s shouldn't have returned error", jobType)
+		}
+		if ns == "" {
+			t.Fatalf("jobType %s seems to have empty namespace", jobType)
+		}
+	}
+	ns, err := getNamespace("foobar")
+	if !strings.Contains(err.Error(), "foobar") {
+		t.Fatalf("jobType foobar should have returned error")
+	}
+	if ns != "" {
+		t.Fatalf("jobType foobar should have returned empty string")
+	}
 }


### PR DESCRIPTION
`log.Fatal()` performs `os.Exit()`, so we have to make some changes to `getNamespace()` return type to make it testable.

`getNamespace()` is used in three places:
- `detectDimensionsByService()`
- `getMetricDataForQueries()`
- `scrapeDiscoveryJobUsingMetricData()`

However, in `detectDimensionsByService()` we only call it for `alb`, so we can skip error checking.
`getMetricDataForQueries()` is called via `scrapeDiscoveryJobUsingMetricData()`, so it is enough to do error checking in `scrapeDiscoveryJobUsingMetricData()`

Also simplified code in `scrapeDiscoveryJobUsingMetricData`, because one function call is always associated to one job type, so they are all associated to same AWS namespace and it is enough to check it at the beginning of method.

Since `getFullMetricsList()` uses its first parameter only to figure out AWS namespace, we might as well pass namespace instead of job type.