### PR TITLE
Add support for collecting WAFv2 metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ YACE is currently in quick iteration mode. Things will probably break in upcomin
   * firehose - Managed Streaming Service
   * sns - Simple Notification Service
   * sfn - Step Functions
+  * wafv2 - Web Application Firewall v2
 
 ## Image
 

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -262,6 +262,7 @@ func getNamespace(service string) (string, error) {
 		"tgw":                   "AWS/TransitGateway",
 		"tgwa":                  "AWS/TransitGateway",
 		"vpn":                   "AWS/VPN",
+		"wafv2":                 "AWS/WAFV2",
 	}
 	if ns, ok = namespaces[service]; !ok {
 		return "", errors.New("Not implemented namespace for cloudwatch metric: " + service)
@@ -490,6 +491,9 @@ func detectDimensionsByService(resource *tagsData, fullMetricsList *cloudwatch.L
 	case "kafka":
 		cluster := strings.Split(arnParsed.Resource, "/")[1]
 		dimensions = append(dimensions, buildDimension("Cluster Name", cluster))
+	case "wafv2":
+		aclId := strings.Split(resourceArn, "/")[2]
+		dimensions = append(dimensions, buildDimension("WebACL", aclId))
 	default:
 		log.Fatal("Not implemented cloudwatch metric: " + service)
 	}

--- a/aws_tags.go
+++ b/aws_tags.go
@@ -118,6 +118,7 @@ func (iface tagsInterface) get(job job, region string) (resources []*tagsData, e
 		"tgw":                   {"ec2:transit-gateway"},
 		"vpn":                   {"ec2:vpn-connection"},
 		"kafka":                 {"kafka:cluster"},
+		"wafv2":                 {"wafv2"},
 	}
 	var inputparams r.GetResourcesInput
 	if resourceTypeFilters, ok := allResourceTypesFilters[job.Type]; ok {

--- a/main.go
+++ b/main.go
@@ -59,6 +59,7 @@ var (
 		"tgw",
 		"tgwa",
 		"vpn",
+		"wafv2",
 	}
 
 	config = conf{}


### PR DESCRIPTION
Adds WAFv2 support.

Example config:

```
discovery:
  jobs:
  - type: wafv2
    regions:
      - us-east-1
    length: 1200
    period: 1200
    delay: 1200
    awsDimensions:
      - WebACL
      - Region
      - Rule
    enableMetricData: true
    metrics:
      - name: AllowedRequests
        statistics:
          - Sum
        period: 1200
      - name: BlockedRequests
        statistics:
          - Sum
        period: 1200
```

Example metrics exported:
```
aws_wafv2_allowed_requests_sum{dimension_Region="us-east-1",dimension_Rule="ALL",dimension_WebACL="waf-v2-app",name="arn:aws:wafv2:us-east-1:XXXX:regional/webacl/waf-v2-app/e575f995-dba8-4533-86be-e8f8fa15f245",region="us-east-1"} 2765
aws_wafv2_allowed_requests_sum{dimension_Region="us-east-1",dimension_Rule="test-waf-setup-waf-main-metrics",dimension_WebACL="waf-v2-app",name="arn:aws:wafv2:us-east-1:XXXX:regional/webacl/waf-v2-app/e575f995-dba8-4533-86be-e8f8fa15f245",region="us-east-1} 2765
# HELP aws_wafv2_blocked_requests_sum Help is not implemented yet.
# TYPE aws_wafv2_blocked_requests_sum gauge
aws_wafv2_blocked_requests_sum{dimension_Region="us-east-1",dimension_Rule="ALL",dimension_WebACL="waf-v2-app",name="arn:aws:wafv2:us-east-1:XXXX:regional/webacl/waf-v2-app/e575f995-dba8-4533-86be-e8f8fa15f245",region="us-east-1"} 1942
aws_wafv2_blocked_requests_sum{dimension_Region="us-east-1",dimension_Rule="waf-v2-app-TestRateLimiter-rule-1",dimension_WebACL="waf-v2-app",name="arn:aws:wafv2:us-east-1:XXXX:regional/webacl/waf-v2-app/e575f995-dba8-4533-86be-e8f8fa15f245",region="us-east-1"} 1942
```