### PR TITLE
Adding support for AWS/EC2Spot

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ YACE is currently in quick iteration mode. Things will probably break in upcomin
   * ebs - Elastic Block Storage
   * ec - ElastiCache
   * ec2 - Elastic Compute Cloud
+  * ec2Spot - Elastic Compute Cloud for Spot Instances
   * ecs-svc - Elastic Container Service (Service Metrics)
   * ecs-containerinsights - ECS/ContainerInsights (Fargate metrics)
   * efs - Elastic File System
@@ -50,7 +51,6 @@ YACE is currently in quick iteration mode. Things will probably break in upcomin
   * sns - Simple Notification Service
   * sfn - Step Functions
   * wafv2 - Web Application Firewall v2
-  * ec2Spot - Elastic Compute Cloud for Spot Instances
 
 ## Image
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ YACE is currently in quick iteration mode. Things will probably break in upcomin
   * sns - Simple Notification Service
   * sfn - Step Functions
   * wafv2 - Web Application Firewall v2
+  * ec2Spot - Elastic Compute Cloud for Spot Instances
 
 ## Image
 

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -239,6 +239,7 @@ func getNamespace(service string) (string, error) {
 		"ebs":                   "AWS/EBS",
 		"ec":                    "AWS/ElastiCache",
 		"ec2":                   "AWS/EC2",
+		"ec2Spot":               "AWS/EC2Spot",
 		"ecs-svc":               "AWS/ECS",
 		"ecs-containerinsights": "ECS/ContainerInsights",
 		"efs":                   "AWS/EFS",
@@ -263,7 +264,6 @@ func getNamespace(service string) (string, error) {
 		"tgwa":                  "AWS/TransitGateway",
 		"vpn":                   "AWS/VPN",
 		"wafv2":                 "AWS/WAFV2",
-		"ec2Spot":               "AWS/EC2Spot",
 	}
 	if ns, ok = namespaces[service]; !ok {
 		return "", errors.New("Not implemented namespace for cloudwatch metric: " + service)

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -394,9 +394,13 @@ func queryAvailableDimensions(resource string, namespace *string, fullMetricsLis
 func detectDimensionsByService(resource *tagsData, fullMetricsList *cloudwatch.ListMetricsOutput) (dimensions []*cloudwatch.Dimension) {
 	resourceArn := *resource.ID
 	service := *resource.Service
+	if service == "ec2Spot" {
+		return dimensions
+
+	}
 	arnParsed, err := arn.Parse(resourceArn)
 
-	if err != nil &&  (service != "tgwa" || service!= "ec2Spot")  {
+	if err != nil &&  service != "tgwa"  {
 		log.Warningf("Unable to parse ARN (%s) on %s due to %v", resourceArn, service, err)
 		return dimensions
 	}

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -263,6 +263,7 @@ func getNamespace(service string) (string, error) {
 		"tgwa":                  "AWS/TransitGateway",
 		"vpn":                   "AWS/VPN",
 		"wafv2":                 "AWS/WAFV2",
+		"ec2Spot":               "AWS/EC2Spot",
 	}
 	if ns, ok = namespaces[service]; !ok {
 		return "", errors.New("Not implemented namespace for cloudwatch metric: " + service)
@@ -395,7 +396,7 @@ func detectDimensionsByService(resource *tagsData, fullMetricsList *cloudwatch.L
 	service := *resource.Service
 	arnParsed, err := arn.Parse(resourceArn)
 
-	if err != nil && service != "tgwa" {
+	if err != nil &&  (service != "tgwa" || service!= "ec2Spot")  {
 		log.Warningf("Unable to parse ARN (%s) on %s due to %v", resourceArn, service, err)
 		return dimensions
 	}

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -400,7 +400,7 @@ func detectDimensionsByService(resource *tagsData, fullMetricsList *cloudwatch.L
 	}
 	arnParsed, err := arn.Parse(resourceArn)
 
-	if err != nil &&  service != "tgwa"  {
+	if err != nil && service != "tgwa" {
 		log.Warningf("Unable to parse ARN (%s) on %s due to %v", resourceArn, service, err)
 		return dimensions
 	}

--- a/aws_tags.go
+++ b/aws_tags.go
@@ -90,10 +90,11 @@ func (iface tagsInterface) get(job job, region string) (resources []*tagsData, e
 	switch job.Type {
 	case "asg":
 		return iface.getTaggedAutoscalingGroups(job, region)
-	case "tgwa":
-		return iface.getTaggedTransitGatewayAttachments(job, region)
 	case "ec2Spot":
 		return iface.getTaggedEC2SpotInstances(job, region)
+	case "tgwa":
+		return iface.getTaggedTransitGatewayAttachments(job, region)
+
 	}
 
 	allResourceTypesFilters := map[string][]string{

--- a/aws_tags.go
+++ b/aws_tags.go
@@ -340,6 +340,7 @@ func (iface tagsInterface) getTaggedEC2SpotInstances(job job, region string) (re
 			return pageNum < 100
 		})
 }
+
 func migrateTagsToPrometheus(tagData []*tagsData) []*PrometheusMetric {
 	output := make([]*PrometheusMetric, 0)
 

--- a/main.go
+++ b/main.go
@@ -60,6 +60,7 @@ var (
 		"tgwa",
 		"vpn",
 		"wafv2",
+		"ec2Spot",
 	}
 
 	config = conf{}

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ var (
 		"ebs",
 		"ec",
 		"ec2",
+		"ec2Spot",
 		"ecs-svc",
 		"ecs-containerinsights",
 		"efs",
@@ -60,7 +61,6 @@ var (
 		"tgwa",
 		"vpn",
 		"wafv2",
-		"ec2Spot",
 	}
 
 	config = conf{}


### PR DESCRIPTION
Support for AWS/EC2Spot

Example config:

```
discovery:
  jobs:
    - type: ec2Spot
      regions:
        - us-west-2
      addCloudwatchTimestamp: true
      period: 300
      length: 300
      awsDimensions:
      - FleetRequestId
      - InstanceType
      metrics:
        - name: FulfilledCapacity
          statistics:
            - Average
```
Example metrics exported:
```
aws_ec2_spot_fulfilled_capacity_average{dimension_FleetRequestId="sfr-1cdeed0d3f-56893-4c7a-93c8-a5baba5d406b",dimension_InstanceType="c5.12xlarge,"region="us-west-2"} 2 1601807580000
aws_ec2_spot_fulfilled_capacity_average{dimension_FleetRequestId="sfr-1cdeed0d3f-56893-4c7a-93c8-a5baba5d406b",dimension_InstanceType="c5.18xlarge",region="us-west-2"} 1 1601807580000
```