### PR TITLE
Fix sorting of datapoints, add test util functions

### DIFF
--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -640,7 +640,7 @@ func ensureLabelConsistencyForMetrics(metrics []*PrometheusMetric) []*Prometheus
 func sortByTimestamp(datapoints []*cloudwatch.Datapoint) []*cloudwatch.Datapoint {
 	sort.Slice(datapoints, func(i, j int) bool {
 		jTimestamp := *datapoints[j].Timestamp
-		return datapoints[i].Timestamp.Before(jTimestamp)
+		return datapoints[i].Timestamp.After(jTimestamp)
 	})
 	return datapoints
 }

--- a/aws_cloudwatch_test.go
+++ b/aws_cloudwatch_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 )
@@ -40,4 +41,36 @@ func TestGetNamespace(t *testing.T) {
 	if ns != "" {
 		t.Fatalf("jobType foobar should have returned empty string")
 	}
+}
+
+// TestSortyByTimeStamp validates that sortByTimestamp() sorts in descending order.
+func TestSortyByTimeStamp(t *testing.T) {
+	cloudWatchDataPoints := make([]*cloudwatch.Datapoint, 3)
+	maxValue1 := float64(1)
+	maxValue2 := float64(2)
+	maxValue3 := float64(3)
+
+	dataPointMiddle := &cloudwatch.Datapoint{}
+	twoMinutesAgo := time.Now().Add(time.Minute * 2 * -1)
+	dataPointMiddle.Timestamp = &twoMinutesAgo
+	dataPointMiddle.Maximum = &maxValue2
+	cloudWatchDataPoints[0] = dataPointMiddle
+
+	dataPointNewest := &cloudwatch.Datapoint{}
+	oneMinutesAgo := time.Now().Add(time.Minute * -1)
+	dataPointNewest.Timestamp = &oneMinutesAgo
+	dataPointNewest.Maximum = &maxValue1
+	cloudWatchDataPoints[1] = dataPointNewest
+
+	dataPointOldest := &cloudwatch.Datapoint{}
+	threeMinutesAgo := time.Now().Add(time.Minute * 3 * -1)
+	dataPointOldest.Timestamp = &threeMinutesAgo
+	dataPointOldest.Maximum = &maxValue3
+	cloudWatchDataPoints[2] = dataPointOldest
+
+	sortedDataPoints := sortByTimestamp(cloudWatchDataPoints)
+
+	equals(t, maxValue1, *sortedDataPoints[0].Maximum)
+	equals(t, maxValue2, *sortedDataPoints[1].Maximum)
+	equals(t, maxValue3, *sortedDataPoints[2].Maximum)
 }

--- a/test_utils.go
+++ b/test_utils.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+// From https://github.com/benbjohnson/testing
+
+// assert fails the test if the condition is false.
+func assert(tb testing.TB, condition bool, msg string, v ...interface{}) {
+	if !condition {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d: "+msg+"\033[39m\n\n", append([]interface{}{filepath.Base(file), line}, v...)...)
+		tb.FailNow()
+	}
+}
+
+// ok fails the test if an err is not nil.
+func ok(tb testing.TB, err error) {
+	if err != nil {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d: unexpected error: %s\033[39m\n\n", filepath.Base(file), line, err.Error())
+		tb.FailNow()
+	}
+}
+
+// equals fails the test if exp is not equal to act.
+func equals(tb testing.TB, exp, act interface{}) {
+	if !reflect.DeepEqual(exp, act) {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\033[39m\n\n", filepath.Base(file), line, exp, act)
+		tb.FailNow()
+	}
+}


### PR DESCRIPTION
Fixes #266 

Sorting data points in descending order allows `getDatapoint()` to pull the most recent one when it iterates over the slice.

Adds the test helper functions from https://github.com/benbjohnson/testing