### PR TITLE
add RDS DB clusters

### DIFF
--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -419,7 +419,6 @@ func detectDimensionsByService(resource *tagsData, fullMetricsList *cloudwatch.L
 		"kinesis":  {Key: "StreamName", Prefix: "stream/"},
 		"lambda":   {Key: "FunctionName", Prefix: "function:"},
 		"ngw":      {Key: "NatGatewayId", Prefix: "natgateway/"},
-		"rds":      {Key: "DBInstanceIdentifier", Prefix: "db:"},
 		"redshift": {Key: "ClusterIdentifier", Prefix: "cluster:"},
 		"r53r":     {Key: "EndpointId", Prefix: "resolver-endpoint/"},
 		"s3":       {Key: "BucketName", Prefix: ""},
@@ -432,6 +431,12 @@ func detectDimensionsByService(resource *tagsData, fullMetricsList *cloudwatch.L
 		return buildBaseDimension(arnParsed.Resource, params.Key, params.Prefix)
 	}
 	switch service {
+	case "rds":
+		if strings.HasPrefix(arnParsed.Resource, "cluster:") {
+			dimensions = buildBaseDimension(arnParsed.Resource, "DBClusterIdentifier", "cluster:")
+		} else {
+			dimensions = buildBaseDimension(arnParsed.Resource, "DBInstanceIdentifier", "db:")
+		}
 	case "alb", "nlb":
 		namespace, _ := getNamespace(service)
 		dimensions = queryAvailableDimensions(arnParsed.Resource, &namespace, fullMetricsList)

--- a/aws_tags.go
+++ b/aws_tags.go
@@ -115,7 +115,7 @@ func (iface tagsInterface) get(job job, region string) (resources []*tagsData, e
 		"lambda":                {"lambda:function"},
 		"ngw":                   {"ec2:natgateway"},
 		"nlb":                   {"elasticloadbalancing:loadbalancer/net", "elasticloadbalancing:targetgroup"},
-		"rds":                   {"rds:db"},
+		"rds":                   {"rds:db", "rds:cluster"},
 		"redshift":              {"redshift:cluster"},
 		"r53r":                  {"route53resolver"},
 		"s3":                    {"s3"},


### PR DESCRIPTION
- adds support for RDS cluster metrics.

This is for supporting the new serverless aurora etc which has no instances.

I am amiable to add a new discovery type or just ignore this in discovery and force people to use a static metric