### PR TITLE
adding helm chart for easy kubernetes installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ config.yml
 yet-another-cloudwatch-exporter
 vendor
 dist
+.idea

--- a/helm-chart/.helmignore
+++ b/helm-chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+appVersion: "v0.23.0-alpha"
+description: A Helm chart for deploying yet-another-cloudwatch-exporter
+name: yet-another-cloudwatch-exporter
+version: 0.0.5
+maintainers:
+  - name: Rushan
+    email: rushankhan123@gmail.com
+

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -1,0 +1,21 @@
+## Chart Details
+This chart will do the following:
+* Deploys a YACE (yet-another-cloudwatch-exporter) pod 
+* Deploys a configurable configmap hosting the configuration read by the YACE pod
+
+## Installing the Chart
+To install the chart with the release name `YACE`:
+```bash
+$ helm install YACE yet-another-cloudwatch-exporter -n <namespace>
+```
+
+### Deleting the Chart
+```bash
+$ helm delete YACE -n <namespace>
+```
+
+## Tip
+As this configuration is read as a Configmap, when an update occurs to the configmap the pod must be restarted to pick 
+up the new changes. It may be worthwhile installing Reloader (https://github.com/stakater/Reloader ) - this application 
+can be configured to automatically restart pods based off of changes to it's Configmap/Secrets.
+

--- a/helm-chart/templates/_helpers.tpl
+++ b/helm-chart/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "yet-another-cloudwatch-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "yet-another-cloudwatch-exporter.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "yet-another-cloudwatch-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "yet-another-cloudwatch-exporter.labels" -}}
+helm.sh/chart: {{ include "yet-another-cloudwatch-exporter.chart" . }}
+{{ include "yet-another-cloudwatch-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "yet-another-cloudwatch-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "yet-another-cloudwatch-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "yet-another-cloudwatch-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "yet-another-cloudwatch-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm-chart/templates/configmap.yaml
+++ b/helm-chart/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "yet-another-cloudwatch-exporter.fullname" . }}
+  labels:
+    app: {{ template "yet-another-cloudwatch-exporter.name" . }}
+    chart: {{ template "yet-another-cloudwatch-exporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  config.yml: {{ toJson .Values.yace.config }}

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "yet-another-cloudwatch-exporter.fullname" . }}
+  labels:
+    {{- include "yet-another-cloudwatch-exporter.labels" . | nindent 4 }}
+spec:
+{{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+{{- end }}
+  selector:
+    matchLabels:
+      {{- include "yet-another-cloudwatch-exporter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        configmap.reloader.stakater.com/reload: {{ template "yet-another-cloudwatch-exporter.fullname" . }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+      labels:
+        {{- include "yet-another-cloudwatch-exporter.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "yet-another-cloudwatch-exporter.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+        - name: cfg-volume
+          configMap:
+            name: {{ template "yet-another-cloudwatch-exporter.fullname" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- if .Values.extraArgs }}
+          {{- with .Values.extraArgs }}
+          args:
+            - --config.file=/tmp/config.yml
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 5000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.liveness_probe }}
+              port: http
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readiness_probe }}
+              port: http
+            timeoutSeconds: 5
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+          - mountPath: /tmp
+            name: cfg-volume
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm-chart/templates/hpa.yaml
+++ b/helm-chart/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "yet-another-cloudwatch-exporter.fullname" . }}
+  labels:
+    {{- include "yet-another-cloudwatch-exporter.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "yet-another-cloudwatch-exporter.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+{{- end }}

--- a/helm-chart/templates/serviceaccount.yaml
+++ b/helm-chart/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "yet-another-cloudwatch-exporter.serviceAccountName" . }}
+  labels:
+    {{- include "yet-another-cloudwatch-exporter.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -1,0 +1,93 @@
+# Default values for yet-another-cloudwatch-exporter.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+
+image:
+  repository: quay.io/invisionag/yet-another-cloudwatch-exporter
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "v0.23.0-alpha"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+resources:
+  limits:
+    memory: 1024Mi
+    cpu: 500m
+  requests:
+    memory: 512Mi
+    cpu: 100m
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+hpa_enabled: no
+liveness_probe: "/"
+readiness_probe: "/"
+
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "5000"
+  prometheus.io/path: "/metrics"
+
+yace:
+  config: |-
+    discovery:
+      exportedTagsOnMetrics:
+        vpn:
+          - Team
+      jobs:
+      - type: vpn
+        regions:
+          - eu-west-1
+        awsDimensions:
+          - VpnId
+        metrics:
+          - name: TunnelState
+            statistics:
+              - Average
+            period: 60
+            length: 300
+
+extraArgs:
+  - --listen-address=:5000
+  - --debug=false
+  - --cloudwatch-concurrency=5
+  - --tag-concurrency=5
+  - --scraping-interval=300
+  - --decoupled-scraping=true
+  - --metrics-per-query=500
+  - --labels-snake-case=false
+
+


### PR DESCRIPTION
Simple helm chart which allows you to deploy yet-another-cloudwatch-exporter through helm to your kubernetes cluster.
First contribution so apologies if i've made any mistakes- happy to improve.