### PR TITLE
use fips flag to enable fips endpoints

### DIFF
--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -55,6 +55,12 @@ func createCloudwatchSession(region *string, roleArn string) *cloudwatch.CloudWa
 
 	config := &aws.Config{Region: region, MaxRetries: &maxCloudwatchRetries}
 
+	if *fips {
+		// https://docs.aws.amazon.com/general/latest/gr/cw_region.html
+		endpoint := fmt.Sprintf("https://monitoring-fips.%s.amazonaws.com", *region)
+		config.Endpoint = aws.String(endpoint)
+	}
+
 	if *debug {
 		config.LogLevel = aws.LogLevel(aws.LogDebugWithHTTPBody)
 	}

--- a/aws_tags.go
+++ b/aws_tags.go
@@ -52,18 +52,35 @@ func createSession(roleArn string, config *aws.Config) *session.Session {
 func createTagSession(region *string, roleArn string) *r.ResourceGroupsTaggingAPI {
 	maxResourceGroupTaggingRetries := 5
 	config := &aws.Config{Region: region, MaxRetries: &maxResourceGroupTaggingRetries}
+	if *fips {
+		// ToDo: Resource Groups Tagging API does not have FIPS compliant endpoints
+		// https://docs.aws.amazon.com/general/latest/gr/arg.html
+		// endpoint := fmt.Sprintf("https://tagging-fips.%s.amazonaws.com", *region)
+		// config.Endpoint = aws.String(endpoint)
+	}
 	return r.New(createSession(roleArn, config), config)
 }
 
 func createASGSession(region *string, roleArn string) autoscalingiface.AutoScalingAPI {
 	maxAutoScalingAPIRetries := 5
 	config := &aws.Config{Region: region, MaxRetries: &maxAutoScalingAPIRetries}
+	if *fips {
+		// ToDo: Autoscaling does not have a FIPS endpoint
+		// https://docs.aws.amazon.com/general/latest/gr/autoscaling_region.html
+		// endpoint := fmt.Sprintf("https://autoscaling-plans-fips.%s.amazonaws.com", *region)
+		// config.Endpoint = aws.String(endpoint)
+	}
 	return autoscaling.New(createSession(roleArn, config), config)
 }
 
 func createEC2Session(region *string, roleArn string) ec2iface.EC2API {
 	maxEC2APIRetries := 10
 	config := &aws.Config{Region: region, MaxRetries: &maxEC2APIRetries}
+	if *fips {
+		// https://docs.aws.amazon.com/general/latest/gr/ec2-service.html
+		endpoint := fmt.Sprintf("https://ec2-fips.%s.amazonaws.com", *region)
+		config.Endpoint = aws.String(endpoint)
+	}
 	return ec2.New(createSession(roleArn, config), config)
 }
 
@@ -77,7 +94,11 @@ func createAPIGatewaySession(region *string, roleArn string) apigatewayiface.API
 	if roleArn != "" {
 		config.Credentials = stscreds.NewCredentials(sess, roleArn)
 	}
-
+	if *fips {
+		// https://docs.aws.amazon.com/general/latest/gr/apigateway.html
+		endpoint := fmt.Sprintf("https://apigateway-fips.%s.amazonaws.com", *region)
+		config.Endpoint = aws.String(endpoint)
+	}
 	return apigateway.New(sess, config)
 }
 

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ var (
 	addr                  = flag.String("listen-address", ":5000", "The address to listen on.")
 	configFile            = flag.String("config.file", "config.yml", "Path to configuration file.")
 	debug                 = flag.Bool("debug", false, "Add verbose logging.")
+	fips                  = flag.Bool("fips", false, "Use FIPS compliant aws api.")
 	showVersion           = flag.Bool("v", false, "prints current yace version.")
 	cloudwatchConcurrency = flag.Int("cloudwatch-concurrency", 5, "Maximum number of concurrent requests to CloudWatch API.")
 	tagConcurrency        = flag.Int("tag-concurrency", 5, "Maximum number of concurrent requests to Resource Tagging API.")


### PR DESCRIPTION
See - https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html
This adds support for calling the FIPS compliant endpoints wherever possible.

This PR is an "all or nothing" approach which is largely convention based. If run with --fips all regions will attempt to use the fips compliant endpoints, which may or may not exist for the associated region(s).

The typical pattern is configuration based wherever the region is set, allow a corresponding endpoint to be set.
It seemed too difficult to maintain this in config.file since the service calls behind the region are abstracted.