### PR TITLE
Auto-Discovery of Dimension Values for Static Jobs

### DIFF
--- a/abstract_test.go
+++ b/abstract_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
+	"reflect"
 	"testing"
 )
 
@@ -18,5 +21,140 @@ func TestFilterThroughTags(t *testing.T) {
 	// Assert
 	if actual != expected {
 		t.Fatalf("\nexpected: %t\nactual:  %t", expected, actual)
+	}
+}
+
+// set up mock cloudwatch client for TestResolveSingleStaticDimension
+type mockCloudWatchClient struct {
+	cloudwatchiface.CloudWatchAPI
+}
+
+func (m mockCloudWatchClient) ListMetrics(input *cloudwatch.ListMetricsInput) (*cloudwatch.ListMetricsOutput, error) {
+	fixedDimensionName := "fixedDimension"
+	fixedDimensionValue := "fixedValue"
+	variableDimensionName := "variableDimensionName"
+	variableDimensionValue1 := "a"
+	variableDimensionValue2 := "b"
+	fixedDimension := cloudwatch.Dimension{
+		Name:  &fixedDimensionName,
+		Value: &fixedDimensionValue,
+	}
+	variableDimension1 := cloudwatch.Dimension{
+		Name:  &variableDimensionName,
+		Value: &variableDimensionValue1,
+	}
+	variableDimension2 := cloudwatch.Dimension{
+		Name:  &variableDimensionName,
+		Value: &variableDimensionValue2,
+	}
+	dimensions1 := []*cloudwatch.Dimension{&fixedDimension, &variableDimension1}
+	dimensions2 := []*cloudwatch.Dimension{&fixedDimension, &variableDimension2}
+	metric1 := cloudwatch.Metric{
+		Dimensions: dimensions1,
+		MetricName: input.MetricName,
+		Namespace:  input.Namespace,
+	}
+	metric2 := cloudwatch.Metric{
+		Dimensions: dimensions2,
+		MetricName: input.MetricName,
+		Namespace:  input.Namespace,
+	}
+	metrics := []*cloudwatch.Metric{&metric1, &metric2}
+	output := cloudwatch.ListMetricsOutput{
+		Metrics:   metrics,
+		NextToken: nil,
+	}
+	return &output, nil
+}
+
+func TestMapToOrderedStringHelper(t *testing.T) {
+	// Setup Test
+	m1 := map[string]string{"a": "1", "b": "2"}
+	m2 := map[string]string{"b": "2", "a": "1"}
+	m3 := map[string]string{"a": "0", "b": "2"}
+	m4 := map[string]string{"a": "1", "b": "2", "c": "3"}
+
+	// Act
+	s1 := mapToOrderedStringHelper(m1)
+	s2 := mapToOrderedStringHelper(m2)
+	s3 := mapToOrderedStringHelper(m3)
+	s4 := mapToOrderedStringHelper(m4)
+
+	// Assert
+	if !(s1 == s2) {
+		t.Fatalf("expected %s == %s", s1, s2)
+	}
+	if s1 == s3 {
+		t.Fatalf("expected %s != %s", s1, s3)
+	}
+	if s1 == s4 {
+		t.Fatalf("expected %s != %s", s1, s4)
+	}
+}
+
+func TestResolveSingleStaticDimension(t *testing.T) {
+	// Setup Test
+	dimensions := []dimension{
+		{
+			Name:  "fixedDimension",
+			Value: "fixedValue",
+		},
+		{
+			Name: "variableDimensionName", // variable dimension takes values "a" and "b"
+		},
+	}
+	metrics := []metric{
+		{
+			Name:       "metric1",
+			Statistics: []string{"average"},
+		},
+		{
+			Name:       "metric2",
+			Statistics: []string{"average"},
+		},
+	}
+	resource := static{
+		Name:                       "simpleStaticTest",
+		Regions:                    []string{"us-east-1"},
+		RoleArns:                   []string{"roleARN"},
+		Namespace:                  "myCustomNamespace",
+		Dimensions:                 dimensions,
+		Metrics:                    metrics,
+		PopulateNamelessDimensions: true,
+	}
+	clientCloudwatch := cloudwatchInterface{
+		client: mockCloudWatchClient{},
+	}
+
+	var expectedResults []static
+	expectedVariableDimensions := []dimension{
+		{
+			Name:  "variableDimensionName",
+			Value: "a",
+		},
+		{
+			Name:  "variableDimensionName",
+			Value: "b",
+		},
+	}
+	for _, value := range expectedVariableDimensions {
+		result := resource
+		resultDimensions := []dimension{result.Dimensions[0], value}
+		result.Dimensions = resultDimensions
+		expectedResults = append(expectedResults, result)
+	}
+	// Act
+	newJobs, err := resolveStaticDimensions(resource, clientCloudwatch)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("Unexpected error from resolveStaticDimensions, %e", err)
+	}
+	if len(newJobs) != 2 {
+		t.Fatalf("Expected two new jobs to be created, got %d", len(newJobs))
+	}
+	newJobStructs := []static{*newJobs[0], *newJobs[1]}
+	if !reflect.DeepEqual(newJobStructs, expectedResults) {
+		t.Fatalf("\nexpected: %+v\nactual:  %+v", expectedResults, newJobStructs)
 	}
 }

--- a/config.go
+++ b/config.go
@@ -35,13 +35,14 @@ type job struct {
 }
 
 type static struct {
-	Name       string      `yaml:"name"`
-	Regions    []string    `yaml:"regions"`
-	RoleArns   []string    `yaml:"roleArns"`
-	Namespace  string      `yaml:"namespace"`
-	CustomTags []tag       `yaml:"customTags"`
-	Dimensions []dimension `yaml:"dimensions"`
-	Metrics    []metric    `yaml:"metrics"`
+	Name                       string      `yaml:"name"`
+	Regions                    []string    `yaml:"regions"`
+	RoleArns                   []string    `yaml:"roleArns"`
+	Namespace                  string      `yaml:"namespace"`
+	CustomTags                 []tag       `yaml:"customTags"`
+	Dimensions                 []dimension `yaml:"dimensions"`
+	Metrics                    []metric    `yaml:"metrics"`
+	PopulateNamelessDimensions bool        `yaml:"populateNamlessDimensions"`
 }
 
 type metric struct {

--- a/custom_static_config_test.yaml
+++ b/custom_static_config_test.yaml
@@ -1,0 +1,21 @@
+static:
+  - namespace: logstash-s3
+    name: logstash_s3
+    regions:
+      - us-east-1
+    dimensions:
+     - name: Operation
+       value: ProcessTask
+     - name: ShardId
+    metrics:
+      - name: MillisBehindLatest
+        statistics:
+        - Average
+        period: 60
+        length: 300
+      - name: RecordsProcessed
+        statistics:
+        - Average
+        period: 60
+        length: 300 
+    populateNamlessDimensions: true


### PR DESCRIPTION
## Use Case
My team uses the ELK stack, and we have our Logstash services set up to emit metrics to a custom namespace in cloudwatch.  We would like to use YACE to scrape those metrics.  However, the dimensions of most of the metrics correspond to Kinesis shard IDs.  All in all we have 100ish unique kinesis shards across various streams, with shard IDs liable to change if we reshard any streams.  As it stands we would have to specify all of these shard names in the configuration files of our YACE deployment, and update whenever the streams were resharded.  I think it would be great if YACE could auto-discover the dimension values for us, sparing us the need to create and maintain a huge, unwieldy config file.

I tried to make this PR as a generalizable way to auto-discover dimension values given a namespace and dimension names, and create jobs for those discovered values.  I think other people may be in a similar situation (small number of dimensions, large number of values).    It seems from issues like [190](https://github.com/ivx/yet-another-cloudwatch-exporter/issues/190) and [224](https://github.com/ivx/yet-another-cloudwatch-exporter/issues/224) that auto-discovery for custom namespaces is something people want.  While this doesn't solve the problem of full auto-discovery for custom namespaces, it makes using static jobs for custom namespaces more automated.

## Changes
This introduces the configurable value `populateNamlessDimensions` to static job configs.  If this value is set to `true`, and any `Dimensions` do not have a `Value` specified, those values will be extrapolated.  For each metric specified in the static job, a call will be made to the cloudwatch client's [ListMetrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_ListMetrics.html) function filtering on the dimensions provided.  Then, for all unique combinations of dimension values returned, a new static job identical to the old in all ways except dimension values will be created for that combination of dimensions.  The new static jobs with dimension values specified will be scraped, and the original static job with unspecified values will not be scraped.
If `populateNamlessDimensions` is set to false no behavior will change.

## Testing
I tested this against my team's AWS account with my own cofig_test.yml file, and with the unit tests provided.  I added unit tests for new functionality.