### PR TITLE
[aws_cloudwatch] endtime is unused variable in struct

### DIFF
--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -637,7 +637,7 @@ func recordLabelsForMetric(metricName string, promLabels map[string]string) {
 		workingLabelsCopy = append(workingLabelsCopy, labelMap[metricName]...)
 	}
 
-	for k, _ := range promLabels {
+	for k := range promLabels {
 		workingLabelsCopy = append(workingLabelsCopy, k)
 	}
 	sort.Strings(workingLabelsCopy)

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -42,7 +42,6 @@ type cloudwatchData struct {
 	Dimensions              []*cloudwatch.Dimension
 	Region                  *string
 	Period                  int64
-	endtime                time.Time
 }
 
 var labelMap = make(map[string][]string)


### PR DESCRIPTION
Also `for key := range map_variable` works just as well as `for key, _ := range map_variable`