### PR TITLE
Add option to use floating time windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,10 @@ YACE is currently in quick iteration mode. Things will probably break in upcomin
 
 ### Command Line Options
 
-| Option            | Description                                                               |
-| ----------------- | ------------------------------------------------------------------------- |
-| labels-snake-case | Causes labels on metrics to be output in snake case instead of camel case |
+| Option               | Description                                                                       |
+| -------------------- | --------------------------------------------------------------------------------- |
+| labels-snake-case    | Causes labels on metrics to be output in snake case instead of camel case         |
+| floating-time-window | Use a floating start/end time window instead of rounding times to 5 min intervals |
 
 ### Top level configuration
 

--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -151,7 +151,11 @@ func createGetMetricDataInput(getMetricData []cloudwatchData, namespace *string,
 	var startTime time.Time
 	if now.IsZero() {
 		//This is first run
-		now = time.Now().Round(5 * time.Minute)
+		if *floatingTimeWindow {
+			now = time.Now()
+		} else {
+			now = time.Now().Round(5 * time.Minute)
+		}
 		endTime = now.Add(-time.Duration(delay) * time.Second)
 		startTime = now.Add(-(time.Duration(length) + time.Duration(delay)) * time.Second)
 	} else {

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ var (
 	decoupledScraping     = flag.Bool("decoupled-scraping", true, "Decouples scraping and serving of metrics.")
 	metricsPerQuery       = flag.Int("metrics-per-query", 500, "Number of metrics made in a single GetMetricsData request")
 	labelsSnakeCase       = flag.Bool("labels-snake-case", false, "If labels should be output in snake case instead of camel case")
+	floatingTimeWindow    = flag.Bool("floating-time-window", false, "Use a floating start/end time window instead of rounding times to 5 min intervals")
 
 	supportedServices = []string{
 		"alb",


### PR DESCRIPTION
When issue #269 was fixed, the requested "window" (start to end time) was changed to be aligned to 5 minute slots. This turned
out to introduce a regression for when using the metrics as alarms, as a request at e.g. 12:38:31 with length 300s would use a window of 12:35:00 to 12:40:00. This would mean that the actual length (300s) would not be respected, and that any requests does use its own "dynamic delay" to round the time to 5 min intervals. Since metric propagation in AWS is around 2-3 mins, using a 5 min "length" window with 0 delay might return 0 metrics instead of the expected 1-4.

This adds an option to go back to the old behaviours of windows that are not fixed to the 5 min slots.
