### PR TITLE
Add CLI option to validate config file

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ var (
 	metricsPerQuery       = flag.Int("metrics-per-query", 500, "Number of metrics made in a single GetMetricsData request")
 	labelsSnakeCase       = flag.Bool("labels-snake-case", false, "If labels should be output in snake case instead of camel case")
 	floatingTimeWindow    = flag.Bool("floating-time-window", false, "Use a floating start/end time window instead of rounding times to 5 min intervals")
+	verifyConfig        = flag.Bool("verify-config", false, "Loads and attempts to parse config file, then exits. Useful for CICD validation")
 
 	supportedServices = []string{
 		"alb",
@@ -116,6 +117,11 @@ func main() {
 	log.Println("Parse config..")
 	if err := config.load(configFile); err != nil {
 		log.Fatal("Couldn't read ", *configFile, ": ", err)
+		os.Exit(1)
+	}
+	if *verifyConfig {
+		log.Info("Config ", *configFile, " is valid")
+		os.Exit(0)
 	}
 
 	cloudwatchSemaphore = make(chan struct{}, *cloudwatchConcurrency)


### PR DESCRIPTION
This change adds a CLI option to validate the config file and then exit, so that YACE configs can be validated as part of CICD workflows (or local testing) where the application needs to exit gracefully during the pipeline. 

Valid configuration output:
```
$ ./yet-another-cloudwatch-exporter -verify-config -config.file config_test.yml
{"level":"info","msg":"Parse config..","time":"2021-02-28T14:27:07-05:00"}
{"level":"warning","msg":"Metric [FreeStorageSpace/0] in Discovery job [es/0]: length(60) is smaller than period(600). This can cause that the data requested is not ready and generate data gaps","time":"2021-02-28T14:27:07-05:00"}
{"level":"warning","msg":"Metric [ClusterStatus.green/1] in Discovery job [es/0]: length(60) is smaller than period(600). This can cause that the data requested is not ready and generate data gaps","time":"2021-02-28T14:27:07-05:00"}
{"level":"warning","msg":"Metric [ClusterStatus.yellow/2] in Discovery job [es/0]: length(60) is smaller than period(600). This can cause that the data requested is not ready and generate data gaps","time":"2021-02-28T14:27:07-05:00"}
{"level":"warning","msg":"Metric [ClusterStatus.red/3] in Discovery job [es/0]: length(60) is smaller than period(600). This can cause that the data requested is not ready and generate data gaps","time":"2021-02-28T14:27:07-05:00"}
{"level":"info","msg":"Config config_test.yml is valid","time":"2021-02-28T14:27:07-05:00"}

$ echo $?
0
```

On failure:
```
$ ./yet-another-cloudwatch-exporter -verify-config
./yet-another-cloudwatch-exporter -verify-config -config.file config_test.yml
{"level":"info","msg":"Parse config..","time":"2021-02-28T14:36:26-05:00"}
{"level":"fatal","msg":"Couldn't read config_test.yml: Metric [FreeStorageSpace/0] in Discovery job [es/0]: Statistics should not be empty","time":"2021-02-28T14:36:26-05:00"}

$ echo $?
1
```