### PR TITLE
Fix resources filtering for alb

### DIFF
--- a/aws_tags.go
+++ b/aws_tags.go
@@ -208,6 +208,10 @@ func (iface tagsInterface) get(job job, region string) (resources []*tagsData, e
 				albArns = append(albArns, r.ID)
 			}
 		}
+		if len(targetGroupArns) == 0 && len(albArns) > 0 {
+			return resources, resourcePages
+		}
+
 		// You can only describe 20 target groups at a time
 		// Break the array of strings of target group names to multiple arrays
 		// Each with a max size of 20


### PR DESCRIPTION
alb metrics are not exposed because the resource gets filtered when constructing target groups resources logic