### PR TITLE
Fix on China AWS support 

### DIFF
--- a/aws_cloudwatch.go
+++ b/aws_cloudwatch.go
@@ -65,6 +65,7 @@ func createStsSession(roleArn string) *sts.STS {
 func createCloudwatchSession(region *string, roleArn string) *cloudwatch.CloudWatch {
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
+        Config: aws.Config{Region: aws.String(*region)},
 	}))
 
 	maxCloudwatchRetries := 5

--- a/aws_tags.go
+++ b/aws_tags.go
@@ -35,7 +35,7 @@ type tagsInterface struct {
 }
 
 func createSession(roleArn string, config *aws.Config) *session.Session {
-	sess, err := session.NewSession()
+        sess, err := session.NewSession(config)
 	if err != nil {
 		log.Fatalf("Failed to create session due to %v", err)
 	}
@@ -81,12 +81,12 @@ func createEC2Session(region *string, roleArn string) ec2iface.EC2API {
 }
 
 func createAPIGatewaySession(region *string, roleArn string) apigatewayiface.APIGatewayAPI {
-	sess, err := session.NewSession()
+        maxApiGatewaygAPIRetries := 5
+        config := &aws.Config{Region: region, MaxRetries: &maxApiGatewaygAPIRetries}
+        sess, err := session.NewSession(config)
 	if err != nil {
 		log.Fatal(err)
 	}
-	maxApiGatewaygAPIRetries := 5
-	config := &aws.Config{Region: region, MaxRetries: &maxApiGatewaygAPIRetries}
 	if roleArn != "" {
 		config.Credentials = stscreds.NewCredentials(sess, roleArn)
 	}


### PR DESCRIPTION
This is from Samsung China server team.  Currently Yace exporter can't work in China, and the logs show "describe resources for region cn-northwest-1: InvalidClientTokenId: The security token included in the request is invalid.\n\tstatus code: 403”.
We found the region need to be specified when session new, if specify after session new, it will not be effective.

The issue is in [https://github.com/ivx/yet-another-cloudwatch-exporter/issues/344](url)