### PR TITLE
Add support for exporting cassandra metrics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ We will contact you as soon as possible.
   * apigateway (AWS/ApiGateway) - Api Gateway
   * appsync (AWS/AppSync) - AppSync
   * billing (AWS/Billing) - Billing
+  * cassandra (AWS/Cassandra) - Cassandra
   * cloudfront (AWS/CloudFront) - Cloud Front
   * docdb (AWS/DocDB) - DocumentDB (with MongoDB compatibility)
   * dynamodb (AWS/DynamoDB) - NoSQL Online Datenbank Service

--- a/pkg/services.go
+++ b/pkg/services.go
@@ -134,6 +134,12 @@ var (
 			IgnoreLength: true,
 			Alias:        "billing",
 		}, {
+			Namespace: "AWS/Cassandra",
+			Alias:     "cassandra",
+			ResourceFilters: []*string{
+				aws.String("cassandra"),
+			},
+		}, {
 			Namespace: "AWS/CloudFront",
 			Alias:     "cloudfront",
 			ResourceFilters: []*string{


### PR DESCRIPTION
This adds support for exporting AWS/Cassandra prometheus metrics,
example configuration is as below:

```yaml
discovery:
  jobs:
  - type: cassandra
    regions:
      - us-east-1
    metrics:
    - length: 3600
      name: SuccessfulRequestLatency
      nilToZero: true
      period: 300
      statistics:
      - Minimum
      - Maximum
      - Average
      - SampleCount
      - Sum
```