### PR TITLE
add Amazon MQ metrics

### DIFF
--- a/pkg/services.go
+++ b/pkg/services.go
@@ -88,6 +88,12 @@ var (
 				return outputResources, err
 			},
 		}, {
+			Namespace: "AWS/AmazonMQ",
+			Alias:     "mq",
+			ResourceFilters: []*string{
+				aws.String("mq"),
+			},
+		}, {
 			Namespace: "AWS/AppSync",
 			Alias:     "appsync",
 			ResourceFilters: []*string{


### PR DESCRIPTION
fixes #282

I did not add dimensionregex because dimensions are usable as is.

Some documentation for adding metrics:
https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/security-logging-monitoring-cloudwatch.html#rabbitmq-logging-monitoring