### PR TITLE
1.Currently Yace exporter can't work in China.

### DIFF
--- a/pkg/aws_cloudwatch.go
+++ b/pkg/aws_cloudwatch.go
@@ -65,6 +65,7 @@ func createStsSession(roleArn string, debug bool) *sts.STS {
 func createCloudwatchSession(region *string, roleArn string, fips, debug bool) *cloudwatch.CloudWatch {
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
+		Config: aws.Config{Region: aws.String(*region)},
 	}))
 
 	maxCloudwatchRetries := 5

--- a/pkg/aws_tags.go
+++ b/pkg/aws_tags.go
@@ -35,7 +35,7 @@ type tagsInterface struct {
 }
 
 func createSession(roleArn string, config *aws.Config) *session.Session {
-	sess, err := session.NewSession()
+	sess, err := session.NewSession(config)
 	if err != nil {
 		log.Fatalf("Failed to create session due to %v", err)
 	}
@@ -81,12 +81,12 @@ func createEC2Session(region *string, roleArn string, fips bool) ec2iface.EC2API
 }
 
 func createAPIGatewaySession(region *string, roleArn string, fips bool) apigatewayiface.APIGatewayAPI {
-	sess, err := session.NewSession()
+	maxApiGatewaygAPIRetries := 5
+	config := &aws.Config{Region: region, MaxRetries: &maxApiGatewaygAPIRetries}
+	sess, err := session.NewSession(config)
 	if err != nil {
 		log.Fatal(err)
 	}
-	maxApiGatewaygAPIRetries := 5
-	config := &aws.Config{Region: region, MaxRetries: &maxApiGatewaygAPIRetries}
 	if roleArn != "" {
 		config.Credentials = stscreds.NewCredentials(sess, roleArn)
 	}


### PR DESCRIPTION
2.The error in logs shows "describe resources for region cn-northwest-1: InvalidClientTokenId: The security token included in the request is invalid.\n\tstatus code: 403”
3.Region need to be specified when new session, if do it after session creation there will be error.