### PR TITLE
Add support for exporting AWS/Athena metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ We will contact you as soon as possible.
   * alb (AWS/ApplicationELB) - Application Load Balancer
   * apigateway (AWS/ApiGateway) - Api Gateway
   * appsync (AWS/AppSync) - AppSync
+  * athena (AWS/Athena) - Athena
   * billing (AWS/Billing) - Billing
   * cloudfront (AWS/CloudFront) - Cloud Front
   * docdb (AWS/DocDB) - DocumentDB (with MongoDB compatibility)

--- a/pkg/services.go
+++ b/pkg/services.go
@@ -1,4 +1,4 @@
-package exporter 
+package exporter
 
 import (
 	"context"
@@ -97,6 +97,16 @@ var (
 				aws.String("apis/(?P<GraphQLAPIId>[^/]+)"),
 			},
 		}, {
+			Namespace: "AWS/Athena",
+			Alias:     "athena",
+			ResourceFilters: []*string{
+				aws.String("athena"),
+			},
+			DimensionRegexps: []*string{
+				aws.String("athena/(?P<WorkGroup>[^/]+)"),
+			},
+		},
+		{
 			Namespace: "AWS/AutoScaling",
 			Alias:     "asg",
 			DimensionRegexps: []*string{


### PR DESCRIPTION
This adds support for exporting AWS/Athena prometheus metrics,
example configuration is as below:

```
discovery:
  jobs:
    - type: athena
      regions:
        - eu-central-1
      searchTags:
        - key: project
      enableMetricData: true
      metrics:
        - name: TotalExecutionTime
          statistics:
            - Sum
          period: 300
          length: 3600
        - name: EngineExecutionTime
          statistics:
            - Sum
          period: 300
          length: 3600
        - name: ProcessedBytes
          statistics:
            - Sum
          period: 300
          length: 3600
        - name: QueryPlanningTime
          statistics:
            - Sum
          period: 300
          length: 3600
        - name: QueryQueueTime
          statistics:
            - Sum
          period: 300
          length: 3600
        - name: ServiceProcessingTime
          statistics:
            - Sum
          period: 300
          length: 3600
        - name: TotalExecutionTime
          statistics:
            - Sum
          period: 300
          length: 3600
```
