### PR TITLE
Add support for exporting neptune metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ We will contact you as soon as possible.
   * nfw (AWS/NetworkFirewall) - Network Firewall
   * ngw (AWS/NATGateway) - Nat Gateway
   * lambda (AWS/Lambda) - Lambda Functions
+  * neptune (AWS/Neptune) - Neptune
   * nlb (AWS/NetworkELB) - Network Load Balancer
   * redshift (AWS/Redshift) - Redshift Database
   * rds (AWS/RDS) - Relational Database Service

--- a/pkg/services.go
+++ b/pkg/services.go
@@ -385,6 +385,17 @@ var (
 				aws.String(":function:(?P<FunctionName>[^/]+)"),
 			},
 		}, {
+			Namespace: "AWS/Neptune",
+			Alias:     "neptune",
+			ResourceFilters: []*string{
+				aws.String("rds:db"),
+				aws.String("rds:cluster"),
+			},
+			DimensionRegexps: []*string{
+				aws.String(":cluster:(?P<DBClusterIdentifier>[^/]+)"),
+				aws.String(":db:(?P<DBInstanceIdentifier>[^/]+)"),
+			},
+		}, {
 			Namespace: "AWS/NetworkFirewall",
 			Alias:     "nfw",
 			ResourceFilters: []*string{


### PR DESCRIPTION
This adds support for exporting **AWS/Neptune** prometheus metrics. Example configuration is as below:

```yaml
discovery:
  jobs:
    - type: neptune
      regions:
        - us-east-1
      metrics:
        - name: CPUUtilization
          statistics:
            - Average
            - Sum
          period: 600
          length: 60
```