### PR TITLE
skip metric if Cloudwatch timestamp is enabled and no metric data

### DIFF
--- a/pkg/aws_cloudwatch.go
+++ b/pkg/aws_cloudwatch.go
@@ -494,7 +494,7 @@ func migrateCloudwatchToPrometheus(cwd []*cloudwatchData, labelsSnakeCase bool) 
 				includeTimestamp = *c.AddCloudwatchTimestamp
 			}
 			exportedDatapoint, timestamp := getDatapoint(c, statistic)
-			if exportedDatapoint == nil {
+			if exportedDatapoint == nil && c.AddCloudwatchTimestamp == nil {
 				var nan float64 = math.NaN()
 				exportedDatapoint = &nan
 				includeTimestamp = false


### PR DESCRIPTION
if some CloudWatch metric returns no data and addCloudwatchTimestamp is enabled yace returns no timestamp and so, Prometheus is adding current timestamp automatically. This breaks metric ingestion order for metrics which are intermittently unavailable. This simple patch just skips metrics which has no data if addCloudwatchTimestamp is enabled