### PR TITLE
Use LoadBalancerName dimension for ELB metrics

### DIFF
--- a/pkg/services.go
+++ b/pkg/services.go
@@ -290,7 +290,7 @@ var (
 				aws.String("elasticloadbalancing:loadbalancer"),
 			},
 			DimensionRegexps: []*string{
-				aws.String(":loadbalancer/(?P<LoadBalancer>.+)$"),
+				aws.String(":loadbalancer/(?P<LoadBalancerName>.+)$"),
 			},
 		}, {
 			Namespace: "AWS/ElasticMapReduce",


### PR DESCRIPTION
Classic ELBs use `LoadBalancerName` rather than `LoadBalancer` for their dimensions.

Fixes #379