### PR TITLE
Handle metrics with '%' in their name

### DIFF
--- a/pkg/prometheus.go
+++ b/pkg/prometheus.go
@@ -126,17 +126,17 @@ func combineLabels(labels map[string]string) string {
 
 func promString(text string) string {
 	text = splitString(text)
-	return strings.ToLower(replaceWithUnderscores(text))
+	return strings.ToLower(sanitize(text))
 }
 
 func promStringTag(text string, labelsSnakeCase bool) string {
 	if labelsSnakeCase {
 		return promString(text)
 	}
-	return replaceWithUnderscores(text)
+	return sanitize(text)
 }
 
-func replaceWithUnderscores(text string) string {
+func sanitize(text string) string {
 	replacer := strings.NewReplacer(
 		" ", "_",
 		",", "_",

--- a/pkg/prometheus.go
+++ b/pkg/prometheus.go
@@ -151,6 +151,7 @@ func replaceWithUnderscores(text string) string {
 		"@", "_",
 		"<", "_",
 		">", "_",
+		"%", "_percent",
 	)
 	return replacer.Replace(text)
 }


### PR DESCRIPTION
Fixes #327 by replacing '%' signs with '_percent'.

Replacing it with an underscore would be not be appropriate, as the percentage sign conveys important information about the metric.

A metric name with this fix, as an example, would be `aws_ec2_ebsiobalance_percent_minimum`.