### PR TITLE
No need to pass debug parameter around

### DIFF
--- a/cmd/yace/main.go
+++ b/cmd/yace/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/ivx/yet-another-cloudwatch-exporter/pkg"
+	exporter "github.com/ivx/yet-another-cloudwatch-exporter/pkg"
 )
 
 var version = "custom-build"
@@ -100,7 +100,7 @@ func main() {
 			for {
 				t0 := time.Now()
 				newRegistry := prometheus.NewRegistry()
-				endtime := exporter.UpdateMetrics(config, newRegistry, now, *metricsPerQuery, *fips, *debug, *floatingTimeWindow, *labelsSnakeCase, cloudwatchSemaphore, tagSemaphore)
+				endtime := exporter.UpdateMetrics(config, newRegistry, now, *metricsPerQuery, *fips, *floatingTimeWindow, *labelsSnakeCase, cloudwatchSemaphore, tagSemaphore)
 				now = endtime
 				log.Debug("Metrics scraped.")
 				registry = newRegistry
@@ -143,7 +143,7 @@ func main() {
 	http.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
 		if !(*decoupledScraping) {
 			newRegistry := prometheus.NewRegistry()
-			exporter.UpdateMetrics(config, newRegistry, now, *metricsPerQuery, *fips, *debug, *floatingTimeWindow, *labelsSnakeCase, cloudwatchSemaphore, tagSemaphore)
+			exporter.UpdateMetrics(config, newRegistry, now, *metricsPerQuery, *fips, *floatingTimeWindow, *labelsSnakeCase, cloudwatchSemaphore, tagSemaphore)
 			log.Debug("Metrics scraped.")
 			registry = newRegistry
 		}

--- a/cmd/yace/main.go
+++ b/cmd/yace/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 
-	exporter "github.com/ivx/yet-another-cloudwatch-exporter/pkg"
+	"github.com/ivx/yet-another-cloudwatch-exporter/pkg"
 )
 
 var version = "custom-build"

--- a/pkg/aws_cloudwatch.go
+++ b/pkg/aws_cloudwatch.go
@@ -47,13 +47,13 @@ type cloudwatchData struct {
 
 var labelMap = make(map[string][]string)
 
-func createStsSession(roleArn string, debug bool) *sts.STS {
+func createStsSession(roleArn string) *sts.STS {
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 	}))
 	maxStsRetries := 5
 	config := &aws.Config{MaxRetries: &maxStsRetries}
-	if debug {
+	if log.IsLevelEnabled(log.DebugLevel) {
 		config.LogLevel = aws.LogLevel(aws.LogDebugWithHTTPBody)
 	}
 	if roleArn != "" {
@@ -62,10 +62,10 @@ func createStsSession(roleArn string, debug bool) *sts.STS {
 	return sts.New(sess, config)
 }
 
-func createCloudwatchSession(region *string, roleArn string, fips, debug bool) *cloudwatch.CloudWatch {
+func createCloudwatchSession(region *string, roleArn string, fips bool) *cloudwatch.CloudWatch {
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
-		Config: aws.Config{Region: aws.String(*region)},
+		Config:            aws.Config{Region: aws.String(*region)},
 	}))
 
 	maxCloudwatchRetries := 5
@@ -78,7 +78,7 @@ func createCloudwatchSession(region *string, roleArn string, fips, debug bool) *
 		config.Endpoint = aws.String(endpoint)
 	}
 
-	if debug {
+	if log.IsLevelEnabled(log.DebugLevel) {
 		config.LogLevel = aws.LogLevel(aws.LogDebugWithHTTPBody)
 	}
 
@@ -234,12 +234,12 @@ func (iface cloudwatchInterface) get(filter *cloudwatch.GetMetricStatisticsInput
 	return resp.Datapoints
 }
 
-func (iface cloudwatchInterface) getMetricData(filter *cloudwatch.GetMetricDataInput, debug bool) *cloudwatch.GetMetricDataOutput {
+func (iface cloudwatchInterface) getMetricData(filter *cloudwatch.GetMetricDataInput) *cloudwatch.GetMetricDataOutput {
 	c := iface.client
 
 	var resp cloudwatch.GetMetricDataOutput
 
-	if debug {
+	if log.IsLevelEnabled(log.DebugLevel) {
 		log.Println(filter)
 	}
 
@@ -252,7 +252,7 @@ func (iface cloudwatchInterface) getMetricData(filter *cloudwatch.GetMetricDataI
 			return !lastPage
 		})
 
-	if debug {
+	if log.IsLevelEnabled(log.DebugLevel) {
 		log.Println(resp)
 	}
 

--- a/pkg/update.go
+++ b/pkg/update.go
@@ -7,8 +7,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func UpdateMetrics(config ScrapeConf, registry *prometheus.Registry, now time.Time, metricsPerQuery int, fips, debug, floatingTimeWindow, labelsSnakeCase bool, cloudwatchSemaphore, tagSemaphore chan struct{}) time.Time {
-	tagsData, cloudwatchData, endtime := scrapeAwsData(config, now, metricsPerQuery, fips, debug, floatingTimeWindow, cloudwatchSemaphore, tagSemaphore)
+func UpdateMetrics(config ScrapeConf, registry *prometheus.Registry, now time.Time, metricsPerQuery int, fips, floatingTimeWindow, labelsSnakeCase bool, cloudwatchSemaphore, tagSemaphore chan struct{}) time.Time {
+	tagsData, cloudwatchData, endtime := scrapeAwsData(config, now, metricsPerQuery, fips, floatingTimeWindow, cloudwatchSemaphore, tagSemaphore)
 	var metrics []*PrometheusMetric
 
 	metrics = append(metrics, migrateCloudwatchToPrometheus(cloudwatchData, labelsSnakeCase)...)


### PR DESCRIPTION
logrus library supports log.IsLogLevel() query that we can use to check, if we have debug option enabled or not.
If we use that option, we can drop `debug bool` parameter from bunch of functions, which makes attribute list a little bit shorter.