### PR TITLE
Support arm64 builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,6 +3,7 @@ builds:
   main: ./cmd/yace
   goarch:
     - amd64
+    - arm64
   env:
   - CGO_ENABLED=0
 archive:

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ COPY . ./
 RUN go test -cover ./...
 
 ENV GOOS linux
-ENV GOARCH amd64
+ARG GOARCH
+ENV GOARCH ${GOARCH:-amd64}
 ENV CGO_ENABLED=0
 
 ARG VERSION


### PR DESCRIPTION
Provides arm64 binaries, and makes `GOARCH` configurable at build time for Docker builds.

fixes #393