### PR TITLE
Fix condition on service length

### DIFF
--- a/cmd/yace/main.go
+++ b/cmd/yace/main.go
@@ -85,7 +85,7 @@ func main() {
 		//S3 can have upto 1 day to day will need to address it in seprate block
 		//TBD
 		svc := exporter.SupportedServices.GetService(discoveryJob.Type)
-		if (maxjoblength < length) && svc.IgnoreLength {
+		if (maxjoblength < length) && !svc.IgnoreLength {
 			maxjoblength = length
 		}
 	}


### PR DESCRIPTION
When the `scraping-interval` variable isn't defined, it defaults to 300.
When the scraping interval is smaller then the max job length, the service starts asking CW for timestamps in the future (the drift keeps on growing over time).

This is supposed to take care of that scenario
```
if *scrapingInterval < maxjoblength {
	*scrapingInterval = maxjoblength
}

```

But it never actually gets used, because `svc.IgnoreLength` evaluates to **False** for everything except S3 and Billing.

This seems to be the cause of this issue: https://github.com/ivx/yet-another-cloudwatch-exporter/issues/401
