### PR TITLE
Add support for AWS Certificate Manager metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ We will contact you as soon as possible.
 * Pull data from multiple AWS accounts using cross-account roles
 * Supported services with auto discovery through tags:
 
+  * acm (AWS/CertificateManager) - Certificate Manager
   * alb (AWS/ApplicationELB) - Application Load Balancer
   * apigateway (AWS/ApiGateway) - Api Gateway
   * appsync (AWS/AppSync) - AppSync

--- a/pkg/services.go
+++ b/pkg/services.go
@@ -39,6 +39,13 @@ func (sc serviceConfig) GetService(serviceType string) *serviceFilter {
 var (
 	SupportedServices = serviceConfig{
 		{
+			Namespace: "AWS/CertificateManager",
+			Alias:     "acm",
+			ResourceFilters: []*string{
+				aws.String("acm:certificate"),
+			},
+		},
+		{
 			Namespace: "AWS/ApplicationELB",
 			Alias:     "alb",
 			ResourceFilters: []*string{


### PR DESCRIPTION
Example config:

```
discovery:
  jobs:
  - type: acm
    regions:
      - us-west-2
    metrics:
      - name: DaysToExpiry
        statistics:
        - Sum
        period: 3600
        length: 87600
```

Example metrics:

```
aws_acm_info{name="arn:aws:acm:us-west-2:xxxxxx:certificate/xxxxx-yyy-zzzz",tag_xyz="abc",tag_abc="klm"}
aws_acm_days_to_expiry_sum{account_id="xxxxxxx",dimension_CertificateArn="arn:aws:acm:us-west-2:xxxxxxx:certificate/xxxxx-yyy-zzzz",name="global",region="us-west-2"} 391

```