### PR TITLE
Label metrics based on TargetGroup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ config.yml
 yet-another-cloudwatch-exporter
 vendor
 dist
+.vscode

--- a/pkg/abstract.go
+++ b/pkg/abstract.go
@@ -173,7 +173,7 @@ func getMetricDataForQueries(
 		if len(resources) == 0 {
 			log.Debugf("No resources for metric %s on %s job", metric.Name, svc.Namespace)
 		}
-		getMetricDatas = append(getMetricDatas, getFilteredMetricDatas(region, accountId, discoveryJob.Type, discoveryJob.CustomTags, tagsOnMetrics, svc.DimensionRegexps, resources, metricsList.Metrics, metric)...)
+		getMetricDatas = append(getMetricDatas, getFilteredMetricDatas(region, accountId, discoveryJob.Type, discoveryJob.CustomTags, discoveryJob.ExportTagsFromDimension, tagsOnMetrics, svc.DimensionRegexps, resources, metricsList.Metrics, metric)...)
 	}
 	return getMetricDatas
 }

--- a/pkg/abstract.go
+++ b/pkg/abstract.go
@@ -173,7 +173,7 @@ func getMetricDataForQueries(
 		if len(resources) == 0 {
 			log.Debugf("No resources for metric %s on %s job", metric.Name, svc.Namespace)
 		}
-		getMetricDatas = append(getMetricDatas, getFilteredMetricDatas(region, accountId, discoveryJob.Type, discoveryJob.CustomTags, discoveryJob.ExportTagsFromDimension, tagsOnMetrics, svc.DimensionRegexps, resources, metricsList.Metrics, metric)...)
+		getMetricDatas = append(getMetricDatas, getFilteredMetricDatas(region, accountId, discoveryJob.Type, discoveryJob.CustomTags, svc.TagPriorities, tagsOnMetrics, svc.DimensionRegexps, resources, metricsList.Metrics, metric)...)
 	}
 	return getMetricDatas
 }

--- a/pkg/aws_cloudwatch.go
+++ b/pkg/aws_cloudwatch.go
@@ -291,19 +291,9 @@ func getFullMetricsList(namespace string, metric *Metric, clientCloudwatch cloud
 	return &res
 }
 
-func getFilteredMetricDatas(region string, accountId *string, namespace string, customTags []Tag, exportTagsFromDimension string, tagsOnMetrics exportedTagsOnMetrics, dimensionRegexps []*string, resources []*tagsData, metricsList []*cloudwatch.Metric, m *Metric) (getMetricsData []cloudwatchData) {
+func getFilteredMetricDatas(region string, accountId *string, namespace string, customTags []Tag, tagPriorities []string, tagsOnMetrics exportedTagsOnMetrics, dimensionRegexps []*string, resources []*tagsData, metricsList []*cloudwatch.Metric, m *Metric) (getMetricsData []cloudwatchData) {
 	type filterValues map[string]*tagsData
 	dimensionsFilter := make(map[string]filterValues)
-	// This for loop will fill the above dimension filter with resources that match a Dimension regex
-	/*
-		eg. JobType alb
-		TargetGroup:
-			targetgroup/my-target-group/123456789010
-			targetgroup/my-other-target-group/123456789010
-		LoadBalancer:
-			app/my-public-alb/12345678910
-			app/my-private-alb/12345678910
-	*/
 	for _, dr := range dimensionRegexps {
 		dimensionRegexp := regexp.MustCompile(*dr)
 		names := dimensionRegexp.SubexpNames()
@@ -332,21 +322,19 @@ func getFilteredMetricDatas(region string, accountId *string, namespace string, 
 			ID:        aws.String("global"),
 			Namespace: &namespace,
 		}
+		priority := 99
 		for _, dimension := range cwMetric.Dimensions {
 			if dimensionFilterValues, ok := dimensionsFilter[*dimension.Name]; ok {
 				if d, ok := dimensionFilterValues[*dimension.Value]; !ok {
-					// If the metric dimension name and value are not contained in the filter map then skip
-					// eg. If I am looking for tags environment: staging and the cwMetric is for a dev resource
 					skip = true
 					break
 				} else {
-					if exportTagsFromDimension == *dimension.Name {
-						log.Debugf("   Exporting by tags on dimension: %s", *dimension.Name)
-						r = d
-						break // Exit here as we are exporting based on explicit dimension set in config
+					for k, v := range tagPriorities {
+						if *dimension.Name == v && k < priority {
+							r = d
+							priority = k
+						}
 					}
-					// This gets set to TargetGroup first, then overwritten by LoadBalancer dimension
-					r = d
 				}
 			}
 		}

--- a/pkg/aws_cloudwatch.go
+++ b/pkg/aws_cloudwatch.go
@@ -329,6 +329,9 @@ func getFilteredMetricDatas(region string, accountId *string, namespace string, 
 					skip = true
 					break
 				} else {
+					if len(tagPriorities) == 0 {
+						r = d
+					}
 					for k, v := range tagPriorities {
 						if *dimension.Name == v && k < priority {
 							r = d

--- a/pkg/aws_cloudwatch_test.go
+++ b/pkg/aws_cloudwatch_test.go
@@ -59,15 +59,16 @@ func TestSortyByTimeStamp(t *testing.T) {
 
 func Test_getFilteredMetricDatas(t *testing.T) {
 	type args struct {
-		region           string
-		accountId        *string
-		namespace        string
-		customTags       []Tag
-		tagsOnMetrics    exportedTagsOnMetrics
-		dimensionRegexps []*string
-		resources        []*tagsData
-		metricsList      []*cloudwatch.Metric
-		m                *Metric
+		region                  string
+		accountId               *string
+		namespace               string
+		exportTagsFromDimension string
+		customTags              []Tag
+		tagsOnMetrics           exportedTagsOnMetrics
+		dimensionRegexps        []*string
+		resources               []*tagsData
+		metricsList             []*cloudwatch.Metric
+		m                       *Metric
 	}
 	tests := []struct {
 		name               string
@@ -243,7 +244,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			for i, got := range getFilteredMetricDatas(tt.args.region, tt.args.accountId, tt.args.namespace, tt.args.customTags, tt.args.tagsOnMetrics, tt.args.dimensionRegexps, tt.args.resources, tt.args.metricsList, tt.args.m) {
+			for i, got := range getFilteredMetricDatas(tt.args.region, tt.args.accountId, tt.args.namespace, tt.args.customTags, tt.args.exportTagsFromDimension, tt.args.tagsOnMetrics, tt.args.dimensionRegexps, tt.args.resources, tt.args.metricsList, tt.args.m) {
 				if *got.AccountId != *tt.wantGetMetricsData[i].AccountId {
 					t.Errorf("getFilteredMetricDatas().AccountId = %v, want %v", *got.AccountId, *tt.wantGetMetricsData[i].AccountId)
 				}

--- a/pkg/aws_cloudwatch_test.go
+++ b/pkg/aws_cloudwatch_test.go
@@ -59,16 +59,16 @@ func TestSortyByTimeStamp(t *testing.T) {
 
 func Test_getFilteredMetricDatas(t *testing.T) {
 	type args struct {
-		region                  string
-		accountId               *string
-		namespace               string
-		exportTagsFromDimension string
-		customTags              []Tag
-		tagsOnMetrics           exportedTagsOnMetrics
-		dimensionRegexps        []*string
-		resources               []*tagsData
-		metricsList             []*cloudwatch.Metric
-		m                       *Metric
+		region           string
+		accountId        *string
+		namespace        string
+		tagPriorites     []string
+		customTags       []Tag
+		tagsOnMetrics    exportedTagsOnMetrics
+		dimensionRegexps []*string
+		resources        []*tagsData
+		metricsList      []*cloudwatch.Metric
+		m                *Metric
 	}
 	tests := []struct {
 		name               string
@@ -244,7 +244,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			for i, got := range getFilteredMetricDatas(tt.args.region, tt.args.accountId, tt.args.namespace, tt.args.customTags, tt.args.exportTagsFromDimension, tt.args.tagsOnMetrics, tt.args.dimensionRegexps, tt.args.resources, tt.args.metricsList, tt.args.m) {
+			for i, got := range getFilteredMetricDatas(tt.args.region, tt.args.accountId, tt.args.namespace, tt.args.customTags, tt.args.tagPriorites, tt.args.tagsOnMetrics, tt.args.dimensionRegexps, tt.args.resources, tt.args.metricsList, tt.args.m) {
 				if *got.AccountId != *tt.wantGetMetricsData[i].AccountId {
 					t.Errorf("getFilteredMetricDatas().AccountId = %v, want %v", *got.AccountId, *tt.wantGetMetricsData[i].AccountId)
 				}

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -22,18 +22,17 @@ type Discovery struct {
 type exportedTagsOnMetrics map[string][]string
 
 type Job struct {
-	Regions                 []string  `yaml:"regions"`
-	Type                    string    `yaml:"type"`
-	RoleArns                []string  `yaml:"roleArns"`
-	SearchTags              []Tag     `yaml:"searchTags"`
-	CustomTags              []Tag     `yaml:"customTags"`
-	Metrics                 []*Metric `yaml:"metrics"`
-	Length                  int       `yaml:"length"`
-	Delay                   int       `yaml:"delay"`
-	Period                  int       `yaml:"period"`
-	AddCloudwatchTimestamp  *bool     `yaml:"addCloudwatchTimestamp"`
-	NilToZero               *bool     `yaml:"nilToZero"`
-	ExportTagsFromDimension string    `yaml:"exportTagsFromDimension"`
+	Regions                []string  `yaml:"regions"`
+	Type                   string    `yaml:"type"`
+	RoleArns               []string  `yaml:"roleArns"`
+	SearchTags             []Tag     `yaml:"searchTags"`
+	CustomTags             []Tag     `yaml:"customTags"`
+	Metrics                []*Metric `yaml:"metrics"`
+	Length                 int       `yaml:"length"`
+	Delay                  int       `yaml:"delay"`
+	Period                 int       `yaml:"period"`
+	AddCloudwatchTimestamp *bool     `yaml:"addCloudwatchTimestamp"`
+	NilToZero              *bool     `yaml:"nilToZero"`
 }
 
 type Static struct {

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -22,17 +22,18 @@ type Discovery struct {
 type exportedTagsOnMetrics map[string][]string
 
 type Job struct {
-	Regions                []string  `yaml:"regions"`
-	Type                   string    `yaml:"type"`
-	RoleArns               []string  `yaml:"roleArns"`
-	SearchTags             []Tag     `yaml:"searchTags"`
-	CustomTags             []Tag     `yaml:"customTags"`
-	Metrics                []*Metric `yaml:"metrics"`
-	Length                 int       `yaml:"length"`
-	Delay                  int       `yaml:"delay"`
-	Period                 int       `yaml:"period"`
-	AddCloudwatchTimestamp *bool     `yaml:"addCloudwatchTimestamp"`
-	NilToZero              *bool     `yaml:"nilToZero"`
+	Regions                 []string  `yaml:"regions"`
+	Type                    string    `yaml:"type"`
+	RoleArns                []string  `yaml:"roleArns"`
+	SearchTags              []Tag     `yaml:"searchTags"`
+	CustomTags              []Tag     `yaml:"customTags"`
+	Metrics                 []*Metric `yaml:"metrics"`
+	Length                  int       `yaml:"length"`
+	Delay                   int       `yaml:"delay"`
+	Period                  int       `yaml:"period"`
+	AddCloudwatchTimestamp  *bool     `yaml:"addCloudwatchTimestamp"`
+	NilToZero               *bool     `yaml:"nilToZero"`
+	ExportTagsFromDimension string    `yaml:"exportTagsFromDimension"`
 }
 
 type Static struct {

--- a/pkg/services.go
+++ b/pkg/services.go
@@ -23,6 +23,7 @@ type serviceFilter struct {
 	DimensionRegexps []*string
 	ResourceFunc     ResourceFunc
 	FilterFunc       FilterFunc
+	TagPriorities    []string
 }
 
 type serviceConfig []serviceFilter
@@ -55,6 +56,10 @@ var (
 			DimensionRegexps: []*string{
 				aws.String(":(?P<TargetGroup>targetgroup/.+)"),
 				aws.String(":loadbalancer/(?P<LoadBalancer>.+)$"),
+			},
+			TagPriorities: []string{
+				"TargetGroup",
+				"LoadBalancer",
 			},
 		}, {
 			Namespace: "AWS/ApiGateway",
@@ -437,6 +442,10 @@ var (
 				aws.String(":(?P<TargetGroup>targetgroup/.+)"),
 				aws.String(":loadbalancer/(?P<LoadBalancer>.+)$"),
 			},
+			TagPriorities: []string{
+				"TargetGroup",
+				"LoadBalancer",
+			},
 		}, {
 			Namespace: "AWS/RDS",
 			Alias:     "rds",
@@ -562,16 +571,16 @@ var (
 				aws.String("/webacl/(?P<WebACL>[^/]+)"),
 			},
 		}, {
-            Namespace:  "AWS/WorkSpaces",
-            Alias:      "workspaces",
-            ResourceFilters: []*string{
-                aws.String("workspaces:workspace"),
-                aws.String("workspaces:directory"),
-            },
-            DimensionRegexps: []*string{
-                aws.String(":workspace/(?P<WorkspaceId>[^/]+)$"),
-                aws.String(":directory/(?P<DirectoryId>[^/]+)$"),
-            },
-        },
+			Namespace: "AWS/WorkSpaces",
+			Alias:     "workspaces",
+			ResourceFilters: []*string{
+				aws.String("workspaces:workspace"),
+				aws.String("workspaces:directory"),
+			},
+			DimensionRegexps: []*string{
+				aws.String(":workspace/(?P<WorkspaceId>[^/]+)$"),
+				aws.String(":directory/(?P<DirectoryId>[^/]+)$"),
+			},
+		},
 	}
 )


### PR DESCRIPTION
For some metrics under the one namespace, there may be multiple resources involved. Using Application/ELB as an example, we have LoadBalancers and TargetGroups. I would like to label my metrics using the Tags from the TargetGroup specified in the dimension, otherwise use LoadBalancer tags.