### PR TITLE
Add helm chart and terraform module

### DIFF
--- a/helm/charts/yace/.helmignore
+++ b/helm/charts/yace/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/charts/yace/Chart.yaml
+++ b/helm/charts/yace/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: yace
+description: Yet Another Cloudwatch Exporter
+type: application
+version: 0.1.1
+appVersion: "0.28.0"
+home: https://github.com/ivx/yet-another-cloudwatch-exporter
+sources:
+- https://github.com/ivx/yet-another-cloudwatch-exporter
+maintainers:
+- name: @withernet
+  url: https://github.com/withernet

--- a/helm/charts/yace/README.md
+++ b/helm/charts/yace/README.md
@@ -1,0 +1,64 @@
+# YACE Helm Chart
+
+## Requirements
+
+- Kubernetes >= 1.17 (not tested on anything lower)
+- `helm` >= 3.6.0 (not tested on anything lower)
+- Properly configured AWS role; details [here](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html); included is a terraform module that will do all of this for you
+    - The role must have this policy for the pod to scrape CloudWatch:
+
+        ```json
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "cloudwatch:Get*",
+                        "cloudwatch:Describe*",
+                        "cloudwatch:List*",
+                        "tag:GetResources"
+                    ],
+                    "Resource": ["*"]
+                }
+            ]
+        }
+        ```
+
+## Installation
+`helm install yace helm/charts/yace --values values.yaml`; Note: You *must* fill in all values with your own values, or use the included terraform module that will do it all for you, including deploying the chart
+
+To deploy the chart with terraform:
+
+    ```tf
+    module "yace" {
+      source = path/to/yace"
+
+      region      = "your-region"
+      environment = "your-environment"
+
+      cluster_name = "your-eks-cluster-name"
+      chart        = "path/to/helm/charts/yace"
+    }
+    ```
+
+## Usage notes
+- Pod is listening on port `5000`; it can be scraped at `/metrics` endpoint
+- This helm chart assumes AWS role linked to service account; **it will not work if you do not do it this way**
+- The scrape config for prometheus is detailed below:
+
+    ```yaml
+    - job_name: 'yace'
+      kubernetes_sd_configs:
+      - role: pod
+      scheme: http
+      metrics_path: /metrics
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      authorization:
+        credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_container_name, __meta_kubernetes_pod_container_port_number]
+        action: keep
+        regex: yace;5000
+    ```

--- a/helm/charts/yace/README.md
+++ b/helm/charts/yace/README.md
@@ -30,7 +30,7 @@
 
 To deploy the chart with terraform:
 
-    ```hcl
+    ```terraform
     module "yace" {
       source = path/to/yace"
 

--- a/helm/charts/yace/README.md
+++ b/helm/charts/yace/README.md
@@ -30,7 +30,7 @@
 
 To deploy the chart with terraform:
 
-    ```tf
+    ```hcl
     module "yace" {
       source = path/to/yace"
 

--- a/helm/charts/yace/README.md
+++ b/helm/charts/yace/README.md
@@ -30,17 +30,17 @@
 
 To deploy the chart with terraform:
 
-    ```
-    module "yace" {
-      source = path/to/yace"
+```terraform
+module "yace" {
+  source = path/to/yace"
 
-      region      = "your-region"
-      environment = "your-environment"
+  region      = "your-region"
+  environment = "your-environment"
 
-      cluster_name = "your-eks-cluster-name"
-      chart        = "path/to/helm/charts/yace"
-    }
-    ```
+  cluster_name = "your-eks-cluster-name"
+  chart        = "path/to/helm/charts/yace"
+}
+```
 
 ## Usage notes
 - Pod is listening on port `5000`; it can be scraped at `/metrics` endpoint

--- a/helm/charts/yace/README.md
+++ b/helm/charts/yace/README.md
@@ -30,7 +30,7 @@
 
 To deploy the chart with terraform:
 
-    ```terraform
+    ```
     module "yace" {
       source = path/to/yace"
 

--- a/helm/charts/yace/templates/_helpers.tpl
+++ b/helm/charts/yace/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "yace.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "yace.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "yace.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "yace.labels" -}}
+helm.sh/chart: {{ include "yace.chart" . }}
+{{ include "yace.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "yace.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "yace.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "yace.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "yace.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/charts/yace/templates/serviceaccount.yaml
+++ b/helm/charts/yace/templates/serviceaccount.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.yace.serviceAccount }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.yace.aws.account_id }}:role/{{ .Values.yace.aws.role_name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: yace
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: yace
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: yace
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.yace.serviceAccount }}
+    namespace: {{ .Release.Namespace }}

--- a/helm/charts/yace/templates/yace-cm.yaml
+++ b/helm/charts/yace/templates/yace-cm.yaml
@@ -1,0 +1,121 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: yace-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: yace
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+data:
+  config.yaml: |
+    discovery:
+      jobs:
+      - type: elb
+        regions:
+        - {{ .Values.yace.config.region }}
+        searchTags:
+        - key: kubernetes.io/service-name
+          value: .*
+        length: 600
+        delay: 120
+        metrics:
+        - name: HealthyHostCount
+          statistics:
+          - Sum
+          period: 600
+          length: 600
+        - name: UnHealthyHostCount
+          statistics:
+          - Sum
+          period: 600
+          length: 600
+        - name: Latency
+          statistics:
+          - Average
+          period: 600
+          length: 600
+        - name: RequestCount
+          statistics:
+          - Sum
+          period: 600
+          length: 600
+        - name: HTTPCode_Backend_2XX
+          statistics:
+          - Sum
+          period: 600
+          length: 600
+        - name: HTTPCode_Backend_3XX
+          statistics:
+          - Sum
+          period: 600
+          length: 600
+        - name: HTTPCode_Backend_4XX
+          statistics:
+          - Sum
+          period: 600
+          length: 600
+        - name: HTTPCode_Backend_5XX
+          statistics:
+          - Sum
+          period: 600
+          length: 600
+      - type: alb
+        regions:
+        - {{ .Values.yace.config.region }}
+        searchTags:
+        - key: kubernetes.io/service-name
+          value: .*
+        length: 600
+        delay: 120
+        metrics:
+        - name: RequestCount
+          statistics: [Sum]
+          period: 600
+          length: 600
+        - name: TargetResponseTime
+          statistics: [Average]
+          period: 600
+          length: 600
+        - name: ProcessedBytes
+          statistics: [Sum]
+          period: 600
+          length: 600
+        - name: ActiveConnectionCount
+          statistics: [Sum]
+          period: 600
+          length: 600
+        - name: HTTPCode_ELB_2XX_Count
+          statistics: [Sum]
+          period: 600
+          length: 600
+        - name: HTTPCode_ELB_3XX_Count
+          statistics: [Sum]
+          period: 600
+          length: 600
+        - name: HTTPCode_ELB_4XX_Count
+          statistics: [Sum]
+          period: 600
+          length: 600
+        - name: HTTPCode_ELB_5XX_Count
+          statistics: [Sum]
+          period: 600
+          length: 600
+        - name: HTTPCode_Target_2XX_Count
+          statistics: [Sum]
+          period: 600
+          length: 600
+        - name: HTTPCode_Target_3XX_Count
+          statistics: [Sum]
+          period: 600
+          length: 600
+        - name: HTTPCode_Target_4XX_Count
+          statistics: [Sum]
+          period: 600
+          length: 600
+        - name: HTTPCode_Target_5XX_Count
+          statistics: [Sum]
+          period: 600
+          length: 600

--- a/helm/charts/yace/templates/yace-deployment.yaml
+++ b/helm/charts/yace/templates/yace-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: yace
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: yace
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/yace-cm.yaml") . | sha256sum }}
+      labels:
+        name: yace
+    spec:
+      serviceAccountName: {{ .Values.yace.serviceAccount }}
+      securityContext:
+        fsGroup: 65534 # For yace to be able to read Kubernetes and AWS token files
+      containers:
+      - name: yace
+        image: {{ .Values.yace.image }}
+        imagePullPolicy: IfNotPresent
+        args:
+          - "--config.file=/tmp/config.yaml"
+          - "--labels-snake-case"
+        ports:
+        - name: http-metrics
+          containerPort: 5000
+          protocol: TCP
+        volumeMounts:
+        - name: config-volume
+          mountPath: /tmp
+      volumes:
+      - name: config-volume
+        configMap:
+          name: yace-config

--- a/helm/charts/yace/values.yaml
+++ b/helm/charts/yace/values.yaml
@@ -1,0 +1,10 @@
+yace:
+  image: quay.io/invisionag/yet-another-cloudwatch-exporter:v0.28.0-alpha
+  serviceAccount: yace-sa
+  config:
+    region: us-east-1
+  aws:
+    account_id: ""
+    role_name: ""
+    eks:
+      cluster_name: ""

--- a/terraform/yace/main.tf
+++ b/terraform/yace/main.tf
@@ -1,0 +1,83 @@
+provider "aws" {
+  region = var.region
+}
+
+provider "helm" {
+  kubernetes {
+    config_path = "~/.kube/config"
+  }
+}
+
+terraform {
+  required_version = ">= 1.0"
+}
+
+resource "random_id" "id" {
+  byte_length = 4
+}
+
+locals {
+  account_id  = data.aws_caller_identity.current.account_id
+  role_name   = "${var.environment}-yace_role-${random_id.id.hex}"
+  policy_name = "${var.environment}-yace_policy-${random_id.id.hex}"
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_eks_cluster" "cluster" {
+  name = var.cluster_name
+}
+
+# iam
+resource "aws_iam_role" "yace_role" {
+  name = local.role_name
+
+  assume_role_policy = templatefile("${path.module}/templates/role.json", {
+    account_id = local.account_id
+    oidc       = replace(data.aws_eks_cluster.cluster.identity[0].oidc[0].issuer, "https://", "")
+    namespace                = var.namespace
+    service_account_username = var.service_account_name
+  })
+}
+
+resource "aws_iam_policy" "yace_policy" {
+  name   = local.policy_name
+  policy = templatefile("${path.module}/templates/policy.json", {})
+}
+
+resource "aws_iam_role_policy_attachment" "yace_attach" {
+  policy_arn = aws_iam_policy.yace_policy.arn
+  role       = aws_iam_role.yace_role.name
+}
+
+resource "helm_release" "yace" {
+  name       = "yace"
+
+  chart      = var.chart
+  namespace  = var.namespace
+
+  set {
+    name  = "yace.aws.account_id"
+    value = data.aws_caller_identity.current.account_id
+  }
+
+  set {
+    name  = "yace.aws.eks.cluster_name"
+    value = var.cluster_name
+  }
+
+  set {
+    name  = "yace.aws.role_name"
+    value = aws_iam_role.yace_role.name
+  }
+
+  set {
+    name  = "yace.serviceAccount"
+    value = var.service_account_name
+  }
+
+  set {
+    name  = "yace.config.region"
+    value = var.region
+  }
+}

--- a/terraform/yace/outputs.tf
+++ b/terraform/yace/outputs.tf
@@ -1,0 +1,31 @@
+output "cluster_name" {
+  value = var.cluster_name
+}
+
+output "environment" {
+  value = var.environment
+}
+
+output "namespace" {
+  value = var.namespace
+}
+
+output "region" {
+  value = var.region
+}
+
+output "aws_account_id" {
+  value = data.aws_caller_identity.current.account_id
+}
+
+output "aws_policy_name" {
+  value = local.policy_name
+}
+
+output "aws_role_name" {
+  value = local.role_name
+}
+
+output "service_account_name" {
+  value = var.service_account_name
+}

--- a/terraform/yace/templates/policy.json
+++ b/terraform/yace/templates/policy.json
@@ -1,0 +1,15 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "cloudwatch:Get*",
+                "cloudwatch:Describe*",
+                "cloudwatch:List*",
+                "tag:GetResources"
+            ],
+            "Resource": ["*"]
+        }
+    ]
+}

--- a/terraform/yace/templates/role.json
+++ b/terraform/yace/templates/role.json
@@ -1,0 +1,18 @@
+{
+  "Version" : "2012-10-17",
+  "Statement" : [
+    {
+      "Effect" : "Allow",
+      "Principal" : {
+        "Federated" : "arn:aws:iam::${account_id}:oidc-provider/${oidc}"
+      },
+      "Action" : "sts:AssumeRoleWithWebIdentity",
+      "Condition" : {
+        "StringEquals" : {
+          "${oidc}:aud" : "sts.amazonaws.com",
+          "${oidc}:sub" : "system:serviceaccount:${namespace}:${service_account_username}"
+        }
+      }
+    }
+  ]
+}

--- a/terraform/yace/variables.tf
+++ b/terraform/yace/variables.tf
@@ -1,0 +1,36 @@
+variable "environment" {
+  type = string
+
+  validation {
+    condition     = can(regex("^(demo|dev|qa|prod)$", var.environment))
+    error_message = "The environment can be either dev/demo/qa/prod."
+  }
+}
+
+variable "region" {
+  type = string
+
+  validation {
+    condition     = can(regex("^(us|af|ap|ca|eu|me|sa)\\-(east|west|south|northeast|southeast|central|north)\\-(1|2|3)$", var.region))
+    error_message = "The region must be a proper AWS region."
+  }
+}
+
+# helm
+variable "cluster_name" {
+  type = string
+}
+
+variable "namespace" {
+  type    = string
+  default = "default"
+}
+
+variable "chart" {
+  type = string
+}
+
+variable "service_account_name" {
+  type    = string
+  default = "yace-sa"
+}


### PR DESCRIPTION
I created a helm chart for the project I'm currently working on and have decided to port it to yace project. Included is the slightly modified helm chart and a terraform module to deploy yace via `kind: ServiceAccount`.

Hopefully, this helps!